### PR TITLE
loader: seed rosetta_core runtime version so 26.5 opcodes translate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   build-and-test:

--- a/rosetta_core/include/rosetta_core/RosettaCore.h
+++ b/rosetta_core/include/rosetta_core/RosettaCore.h
@@ -5,4 +5,10 @@
 void rosetta_core_init(uint64_t runtime_version, uintptr_t translate_insn_addr,
                        uintptr_t transaction_result_size_addr);
 
+// Stores the host Rosetta runtime version for the OpcodeCompatibility layer.
+// The loader/sidecar process does not call rosetta_core_init() (that path also
+// installs an in-process translate_insn hook, which only aotinvoke wants), so it
+// must set the version through this entry point instead.
+void rosetta_core_set_runtime_version(uint64_t runtime_version);
+
 uint64_t rosetta_core_runtime_version();

--- a/rosetta_core/src/RosettaCore.cpp
+++ b/rosetta_core/src/RosettaCore.cpp
@@ -6,9 +6,13 @@
 
 static uint64_t g_runtime_version = 0;
 
+void rosetta_core_set_runtime_version(uint64_t runtime_version) {
+    g_runtime_version = runtime_version;
+}
+
 void rosetta_core_init(uint64_t runtime_version, uintptr_t translate_insn_addr,
                        uintptr_t transaction_result_size_addr) {
-    g_runtime_version = runtime_version;
+    rosetta_core_set_runtime_version(runtime_version);
     init_custom_translation_hook(translate_insn_addr, transaction_result_size_addr);
 }
 

--- a/rosetta_loader/src/main.cpp
+++ b/rosetta_loader/src/main.cpp
@@ -28,6 +28,7 @@
 #include "rosetta_core/ConfigEnv.h"
 #include "rosetta_core/CoreConfig.h"
 #include "rosetta_core/ProfileRuntime.h"
+#include "rosetta_core/RosettaCore.h"
 #include "rosetta_core/TranscendentalHelper.h"
 #include "rosetta_core/TranslationResult.h"
 #include "sidecar.hpp"
@@ -732,6 +733,13 @@ int main(int argc, char* argv[]) try {
     dbg.readMemory(rosettaRuntimeExportsAddress, &exports, sizeof(exports));
 
     VERBOSE_LOG("Rosetta version: %llx\n", exports.version);
+
+    // The OpcodeCompatibility layer (used by both stub_asm::build below and the
+    // sidecar's Translator) gates 26.4↔26.5 opcode translation on this version.
+    // Unlike aotinvoke, the loader never calls rosetta_core_init(), so it must
+    // seed the version itself — otherwise the compat layer assumes a 26.4 host
+    // and mistranslates every x87 opcode on 26.5.
+    rosetta_core_set_runtime_version(exports.version);
 
     // ── M2: Inline IPC stub install ─────────────────────────────────────────
     //


### PR DESCRIPTION
## Problem

After updating to macOS 26.5, the test suite dropped to **146 passed / 292 failed**: every x87 transcendental (`f2xm1`, `fcos`, `fsin`, `fptan`, `fpatan`, `fsincos`, `fyl2x`, `fyl2xp1`) returned NaN and `fprem`/`fprem1` crashed (`rosettax87 stub abort kind=1`).

## Root cause

The `OpcodeCompatibility` layer gates 26.4↔26.5 opcode translation on `rosetta_core_runtime_version()`, which is only ever set by `rosetta_core_init()`. `aotinvoke` calls that — the **loader/sidecar process never does**. The sidecar rewrite dropped the injected `rosetta_runtime` dylib that used to call it (`X87.cpp:66` in the old `rosettax87_jit` layout) and never re-wired the call.

So `g_runtime_version` stayed `0`, the `> kVersion_26_4` check was always false, and the compat layer **always applied the 26.4 opcode shift**. On a 26.4 host that happened to match reality (the bug was masked); on 26.5 it shifts the whole `f2xm1..fyl2xp1` range by one:

- `stub_asm.cpp` — `opcode_internal_to_host(kOpcodeName_f2xm1)` returns the 26.4 value, shifting the stub's high-range filter window off by one so `f2xm1` is forwarded to stock.
- `sidecar.cpp` + `Translator` — `IRInstr::opcode()` mistranslates 26.5-canonical opcode IDs as 26.4 IDs → wrong handler dispatch → NaN / crash.

## Fix

Add `rosetta_core_set_runtime_version()` and call it from the loader right after it reads `exports.version`, before `stub_asm::build` and before the sidecar receive thread spawns. The loader can't just call `rosetta_core_init()` — that also installs an in-process `translate_insn` hook that only `aotinvoke` wants. `rosetta_core_init()` now delegates to the same setter, so `aotinvoke` is unchanged.

## Testing

`bash scripts/run_tests.sh` → **438 passed / 0 failed** on macOS 26.5 (Rosetta version `0x16f0240000000`).