### PR TITLE
loader: attach via PT_ATTACHEXC + flush tracee i-cache on code writes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,9 @@ cmake_minimum_required(VERSION 3.27)
 set(CMAKE_OSX_DEPLOYMENT_TARGET "14.0" CACHE STRING "Minimum macOS deployment version")
 
 project(x87sidecar
-    LANGUAGES CXX
+    # C is needed for the MIG-generated mach_exc exception server
+    # (rosetta_loader/mach_excServer.c).
+    LANGUAGES C CXX
     DESCRIPTION "Apple Silicon x87 JIT translation hook for Rosetta 2"
 )
 

--- a/docs/investigations/ci-flaky-sigtrap-attach.md
+++ b/docs/investigations/ci-flaky-sigtrap-attach.md
@@ -1,0 +1,397 @@
+# CI flaky `exit=133` (SIGTRAP) at ptrace attach — investigation & fix design
+
+**Status:** fixed — the full `PT_ATTACHEXC` migration below is implemented
+(`rosetta_loader/src/mach_exception.{hpp,cpp}` + the `MuhDebugger` rewrite).
+Local: 825/825, repeatedly. CI confirmation pending.
+**Date:** 2026-07-09. **Author context:** master CI has been red since PR #7.
+**Confidence:** mechanism *class* high; exact trigger medium (not reproducible
+locally — needs a CI-like cold/virtualized environment to confirm).
+
+> **Update 2026-07-09 (later).** The migration surfaced a *locally-reproducible*
+> post-detach `exit=133` (~1/12 full-suite runs) the original `PT_ATTACH` path
+> did not have. Mechanism **(A)** — `task_swap_exception_ports(EXC_MASK_ALL)`
+> displaced Rosetta's own handler and the restore wrote back a stale snapshot —
+> was fixed by narrowing the task claim + a conditional restore.
+>
+> **Mechanism (B) — ROOT CAUSE (confirmed via crash reports), fixed by an
+> instruction-cache flush.** The residual crash was *not* about exception-port
+> precedence. Every `EXC_BREAKPOINT`/`exit=133` crash report
+> (`~/Library/Logs/DiagnosticReports/test_*.ips`, 12+ samples) faults at an
+> address whose low 12 bits are `0x91c` with ASLR-varying high bits — i.e.
+> `libRosettaRuntime_base + exports_fetch`, **our own planted BRK
+> (`0xD4200000`)**, trapping with no handler *after* detach. Mechanism: ARM64 I/D
+> caches are not coherent. `writeMemory` was a bare `mach_vm_write` with **no
+> i-cache flush**. We plant a BRK at `exports_fetch`, the thread executes it
+> there once (caching the line), we restore the original instruction with
+> `mach_vm_write` (D-cache only), then RESUME the held thread — which re-fetches
+> the same PC (ARM64 BRK doesn't advance PC). If the stale BRK line survives in
+> the I-cache to that re-fetch, it re-traps after we've detached and removed our
+> handler → fatal `SIGTRAP` in the tracee. Flaky ~1/12 = whether the line was
+> evicted in time; independent of exception-port level, which is why the
+> thread-level change below did **not** fix it. `exports_fetch` is uniquely
+> exposed because it's the one site we modify *after* it's been executed/cached
+> and then re-execute; the M2 `__TEXT` patches run before their first execution.
+> **Fix:** `writeMemory` now calls `mach_vm_machine_attribute(MATTR_CACHE,
+> MATTR_VAL_ICACHE_FLUSH)` after every write (as lldb debugserver does).
+>
+> A complementary hardening also landed: catch the setup BRK at **thread level**
+> (`MachExceptionSession::installThreadBreakpoint`/`removeThreadBreakpoint`)
+> instead of task level, so we never share Rosetta's task-level `EXC_BREAKPOINT`
+> port; task-level claim is now `EXC_MASK_SOFTWARE` only. This removes a real
+> latent restore-race but was not the cause of (B).
+
+> **Implementation note — the one thing this doc got wrong.** The migration
+> sketch below says "`detach()`: `PT_DETACH` is still valid". It is, but *only
+> from a held BSD signal-stop*. Under `PT_ATTACHEXC` the stops are Mach
+> exceptions: the planted `BRK` arrives as a bare `EXC_BREAKPOINT` carrying no
+> signal, and `PT_DETACH` rejects that state with `EBUSY` — as it does a
+> running process, a task with a held exception, and even a `task_suspend`ed
+> one. The working sequence (debugserver's `DoSIGSTOP` + `Detach`) is:
+> `kill(pid, SIGSTOP)` → reply to the held stop so the tracee runs into the
+> SIGSTOP → receive and **hold** the `EXC_SOFT_SIGNAL(SIGSTOP)` → restore the
+> exception ports → `PT_DETACH` *while that stop is still held* → only then
+> reply to release the thread (ptrace is no longer callable afterwards, so that
+> last reply must not attempt `PT_THUPDATE`). `SIGSTOP` is used precisely
+> because it cannot be caught or ignored.
+
+---
+
+## TL;DR
+
+- The red CI is **not a code regression**. It is a flaky fatal `SIGTRAP`
+  (`exit=133` = 128+5) that hits a **different arbitrary test each run**,
+  always during the loader's short **ptrace setup window**, never in the x87
+  translation itself.
+- Root-cause hypothesis: the setup phase catches traps via the deprecated
+  **`PT_ATTACH` + `waitpid`/`WSTOPSIG` (BSD signal) path**. Delivery of
+  `EXC_BREAKPOINT` (from the one `BRK` the loader plants in libRosettaRuntime)
+  is a **precedence race** between the debugger and the target's own Mach
+  exception handling. When the debugger loses the race the `BRK` is delivered
+  to the parent as an unhandled `SIGTRAP` → default disposition = terminate →
+  `exit=133`. The codebase already documents this exact hazard
+  (`stub_asm.cpp:366`: "libRosettaRuntime's `__TEXT` eats `EXC_BREAKPOINT`
+  before SIGTRAP is delivered").
+- **Proper fix:** port the loader's attach **fully to `PT_ATTACHEXC`** and drop
+  `PT_ATTACH` + `waitpid`/`WSTOPSIG` entirely. `PT_ATTACHEXC` *is* a ptrace
+  attach — the sibling of `PT_ATTACH` — that delivers debug events as **Mach
+  exception messages** to the debugger's exception port instead of as BSD
+  signals. A debugger-registered exception port takes **precedence** over the
+  target's own handlers, so the `BRK` is caught deterministically and can never
+  leak to the parent as a fatal signal. This is what lldb's `debugserver` does,
+  and it unifies the loader on Mach mechanisms (it is *already* all-Mach for
+  memory/registers/VM, the steady-state IPC, and exit-via-`kqueue` — the
+  `waitpid`/signal path is the lone BSD holdout). The `main.cpp:106-114` comment
+  already names `PT_ATTACHEXC` as the correct-but-deferred alternative.
+  (Keeping `PT_ATTACH` and merely *adding* `task_set_exception_ports` is **not**
+  the fix — mixing signal delivery with a hand-registered port reintroduces the
+  very precedence ambiguity we are killing. Use it only as a diagnostic probe;
+  see "How to confirm".)
+- **Complementary simpler fix:** remove the single planted breakpoint entirely
+  (discover the Exports address without a trap), shrinking the trap surface to
+  just the exec-stop.
+
+Do **not** ship the `run_tests.sh` retry band-aid (explicitly rejected). Fix the
+race.
+
+---
+
+## Symptom / evidence
+
+CI workflow: `.github/workflows/ci.yml:29` runs `sudo scripts/run_tests.sh
+--no-build` on a headless `macos-26` runner.
+
+| Run | Commit | Crashing test(s) — all `exit=133` |
+|-----|--------|-----------------------------------|
+| #7 `28708749666` | `8587e47` | `test_arithp_fstp` |
+| #6 `28678720016` | `c69a1d9` | `test_peephole`, `test_peephole6`, `test_frndint`, `test_fcmov`, `test_fstenv`, `test_fxrstor`, `test_finit_compose`, `test_peephole3` |
+| #4 `28402654759` | `62b73a5` | `test_fistp_multi` |
+
+Fingerprint: **different arbitrary test(s) each run**; a deterministic logic bug
+would kill the *same* test every time (the tests are pure deterministic FP
+checks that print a `FAIL` line on mismatch — see `tests/test_arithp_fstp.c`).
+In the #7 log the loader had already printed `[rosettax87] attached:` for the
+crashing test, so **attach succeeded** and the crash is *after* attach, inside
+the remaining setup steps. Locally (entitled loader, no sudo) the full suite is
+**825/825**, repeatedly.
+
+`run_tests.sh` classifies this: non-zero exit with **no `FAIL` line** →
+`CRASH (exit=<code>)` (`scripts/run_tests.sh:178`).
+
+---
+
+## Architecture recap (so the fix is scoped correctly)
+
+The loader is a *reverse-ptrace* debugger. All of this is in
+`rosetta_loader/src/main.cpp`:
+
+1. **Fork dance** (`main.cpp:588-646`): the **parent keeps the PID and will
+   `execv` the target** (it becomes the tracee). The child double-forks; the
+   orphaned **grandchild is the debugger** (double-fork avoids a process-tree
+   cycle that crashes Terminal's proc walker — see the `NOTE_EXIT`/`ppid==1`
+   comment at `main.cpp:624-646`).
+2. **Attach** (`main.cpp:649`, `MuhDebugger::attach` at `:100`): `PT_ATTACH`
+   (sends SIGSTOP), `waitForStopped()` (`:67`, `expectedSignal=0` → returns on
+   first stop). Prints `[rosettax87] attached:` (`:653`), then releases the
+   parent via `syncPipe` (`:656`).
+3. **Exec stop** (`main.cpp:660`, `waitForExecStop` at `:130`): `PT_CONTINUE` +
+   `waitpid(SIGTRAP)`, then `task_for_pid` (`:140`) to grab the parent task
+   port. (Register/memory access is all Mach: `thread_get_state`,
+   `mach_vm_read/write/protect` — `:266-497`.)
+4. **One breakpoint** (`main.cpp:725-727`): `setBreakpoint(exports_fetch)` plants
+   a `BRK #0` (`AARCH64_BREAKPOINT = 0xD4200000`, `:548`) in libRosettaRuntime's
+   `__TEXT`, `continueExecution()` (`:148`, `PT_CONTINUE` + `waitpid(SIGTRAP)`)
+   runs until it's hit, reads `X19` (the Exports struct addr, `:729`), then
+   `removeBreakpoint`. **This is the only planted breakpoint.**
+5. **Install the inline IPC stub** (`main.cpp:744-1423`): patch the TR-size MOVZ,
+   snapshot translate_insn's prologue, find `__TEXT` trailing padding, install a
+   Mach service port in the parent (`sidecar::installPortInParent`), write the
+   handler blob + transcendental constants + optional profile counters, then
+   overwrite `translate_insn[0..16]` with an abs-jump to the handler.
+6. **Detach + go async** (`main.cpp:1429-1473`): capture the parent task port,
+   `PT_DETACH` (`:1430`), `sidecar::spawnReceiveThread`, block on
+   `kqueue`/`NOTE_EXIT` until the parent exits.
+
+**Key consequence:** ptrace/signal trapping is used **only in steps 2–6 setup**.
+Once detached, the tests run **free**, tickling the loader via **Mach IPC** only.
+So the fatal `SIGTRAP` must occur in the setup window — and given attach already
+succeeded, the prime suspect is **step 4's `BRK`** (or, less likely, step 3's
+exec stop; see below).
+
+Full trap/ptrace surface (confirmed by grep): `PT_ATTACH` ×1, `PT_CONTINUE` ×3
+(exec, breakpoint, signal-suppress), `PT_DETACH` ×2 (hook-disable path +
+normal), one `setBreakpoint`. No existing Mach-exception-port code.
+
+---
+
+## Where the fatal SIGTRAP comes from
+
+`exit=133` means a `SIGTRAP` reached the tracee **with its default (fatal)
+disposition** — i.e. it was *not* intercepted by the debugger.
+
+- **Exec stop (step 3) is ordering-safe, likely not it.** After `PT_ATTACH` the
+  parent is ptrace-**stopped**; the `syncPipe` write makes the pipe data
+  available but the parent cannot run (let alone `execv`) until the grandchild's
+  `PT_CONTINUE` in `waitForExecStop`. So the exec trap fires strictly after the
+  tracer is waiting for it. (Caveat: an x86 binary under Rosetta may emit more
+  than one early trap/signal during bootstrap; `waitForStopped(SIGTRAP)`
+  suppresses non-SIGTRAP signals and returns on the first SIGTRAP. This is a
+  correctness smell but not the obvious crash.)
+
+- **The planted `BRK` (step 4) is the prime suspect.** When the parent executes
+  the `BRK`, the CPU raises an `EXC_BREAKPOINT`. Who sees it first is a
+  **precedence** question between:
+  - the ptrace layer (which is supposed to convert it to a `SIGTRAP`-stop
+    reported to the tracer via `waitpid`), and
+  - **libRosettaRuntime's own Mach exception handling** on the parent's threads.
+
+  The repo already learned (`stub_asm.cpp:366`,
+  `feedback_brk_vs_svc_in_rosetta_text.md`) that **"libRosettaRuntime's `__TEXT`
+  eats `EXC_BREAKPOINT` before SIGTRAP is delivered"** — which is exactly why the
+  abort routine uses `SVC` syscalls, not `BRK`. Yet step 4 plants a `BRK` in that
+  same `__TEXT`. When Rosetta's handler (or the parent default handler) wins the
+  race, the breakpoint becomes an **unhandled SIGTRAP to the parent → terminate →
+  133**. Whether the debugger or Rosetta wins depends on timing (has Rosetta
+  finished installing its exception handler at the instant the `BRK` is hit?),
+  which is precisely what changes between warm-local and cold-CI.
+
+### Why CI and not local
+
+CI perturbs exactly the timing this precedence race depends on:
+1. **Cold Rosetta translation** — CI runs `softwareupdate --install-rosetta`
+   fresh each job (`ci.yml:16`), so every test binary is translated first-time
+   with an empty `/var/db/oah` AOT cache, right in the attach/breakpoint window.
+2. **Virtualized, shared runner** — `macos-26` is a VM; scheduling jitter stretches
+   every `waitpid`/`PT_CONTINUE`/handler-install ordering.
+3. **root vs entitlement** (the `sudo`) — a *different authorization path* for
+   `PT_ATTACH`/`task_for_pid`, but **not** itself a timing race. `sudo` is
+   required in headless CI only because the interactive debugger-entitlement
+   dialog can't appear; it is almost certainly a red herring for the crash. Do
+   not "fix" sudo.
+
+The "different test each run" fingerprint is what an environment-timing race
+produces.
+
+---
+
+## The proper fix — port the whole attach to `PT_ATTACHEXC`
+
+Replace the **BSD-signal trap path** (`PT_ATTACH` + `waitpid`/`WSTOPSIG`)
+wholesale with `ptrace(PT_ATTACHEXC, pid, 0, 0)` + a **Mach exception receive
+loop**. `PT_ATTACHEXC` is a ptrace attach that delivers *all* debug events —
+the attach-stop, the exec-stop, and the `BRK` — as Mach exception messages to a
+port the debugger owns, rather than as BSD signals. **`PT_ATTACH` and
+`waitpid`/`WSTOPSIG` leave the codebase entirely.**
+
+This is not "add an exception port alongside ptrace". It is the *replacement*
+attach primitive. Keeping `PT_ATTACH` and merely calling
+`task_set_exception_ports` yourself is the wrong end state: you then have the
+ptrace signal machinery and your port both eligible for the same
+`EXC_BREAKPOINT`, i.e. the precedence ambiguity we are trying to remove. (That
+hybrid is still useful as a one-off *diagnostic probe* — see "How to confirm" —
+just not as the shipped design.)
+
+Why this removes the race (not just narrows it):
+1. A debug event delivered as a **Mach message to a port the debugger owns
+   cannot fall through to the tracee's default (fatal) signal disposition** —
+   the `exit=133` path is structurally impossible.
+2. A **debugger exception port takes precedence** over the target's own
+   handlers, so the planted `BRK` is caught deterministically even though
+   libRosettaRuntime installs its own `EXC_BREAKPOINT` handling. This directly
+   neutralizes the "Rosetta eats the breakpoint" hazard.
+3. It is **per-thread and message-ordered**, robust to the multi-threaded
+   Rosetta runtime that the whole-process signal model handles poorly.
+4. It is **architecturally consistent**: the loader is *already* all-Mach for
+   memory/registers/VM (`main.cpp:266-497`), the steady-state IPC
+   (`sidecar::spawnReceiveThread`), and parent-exit (`kqueue`/`NOTE_EXIT`,
+   `:1461`). The `waitpid`/signal path is the lone BSD holdout; this removes it.
+
+### Does `waitpid` disappear completely? For this loader, yes.
+
+A fully general debugger (lldb `debugserver`) keeps a *hybrid*: a Mach exception
+thread **plus** a `waitpid` thread for process lifecycle + real UNIX signals,
+using `PT_THUPDATE` to choose signal pass-through. This loader does **not** need
+that during its narrow setup window:
+- attach-stop / exec-stop / the one `BRK` are all **exceptions**
+  (signal-stops surface as `EXC_SOFTWARE` with `EXC_SOFT_SIGNAL`; the breakpoint
+  as `EXC_BREAKPOINT`) → all delivered to the port.
+- **parent exit** is already handled by `kqueue`/`NOTE_EXIT`, not `waitpid`, so
+  no lifecycle `waitpid` is required. For the rare "parent dies mid-setup",
+  request `MACH_NOTIFY_DEAD_NAME` on the task port (or just treat the next
+  `mach_msg`/`mach_vm_*` failure as death). No `PT_THUPDATE` signal-forwarding is
+  needed because the loader passes nothing to the tracee during setup.
+
+### Concrete migration (surface is small — one place)
+
+Only `MuhDebugger`'s trap plumbing changes; all Mach memory/register/VM code, the
+stub-install path, and the steady-state IPC are untouched. Both entry paths
+(normal and `X87_DISABLE_HOOK=1`, `main.cpp:708`) go through `MuhDebugger`, so
+"the whole thing" is one rewrite.
+
+- **New:** allocate a receive right + insert a send right; a
+  `mach_exc_server`/`catch_mach_exception_raise*` handler (MIG `mach_exc.defs`),
+  or a hand-rolled `mach_msg` loop decoding message ids 2401/2405 with
+  `MACH_EXCEPTION_CODES` (64-bit `mach_exception_data_t`).
+- **`attach()` (`main.cpp:100`):** `ptrace(PT_ATTACHEXC, pid, 0, 0)`; the
+  attach-stop arrives as the first exception message.
+- **Rewrite** `waitForStopped()` / `waitForExecStop()` / `continueExecution()`
+  (`main.cpp:67-157`) to **block on `mach_msg` receive** instead of `waitpid`. On
+  the `BRK` (`EXC_BREAKPOINT`) message: read thread state (`copyThreadState`,
+  `:438`), do the work (read `X19`), then **reply to resume**.
+- **Resuming past the BRK:** the loader **removes** the breakpoint after the
+  single hit (`:727`) and there is only ever one, so no single-step-and-re-arm
+  dance is needed — restore the instruction, set thread state, reply. (Persistent
+  breakpoints would need remove→step→re-arm; not required today.)
+- **`detach()` (`main.cpp:159`):** `PT_DETACH` is still valid; also deallocate the
+  exception port / dead-name notification.
+
+### Subtleties / risks to verify (validate against `debugserver`)
+
+- **Mirror the reference implementation.** lldb
+  `tools/debugserver/source/MacOSX/MachException.cpp`, `MachTask.cpp`,
+  `MachProcess.cpp` is the canonical `PT_ATTACHEXC` + Mach-exception debugger for
+  arm64 macOS. Do not reconstruct the message/reply flow from memory — copy its
+  structure.
+- **Exec re-registration / ordering.** macOS resets a task's exception ports
+  across `execve`; `PT_ATTACHEXC` is designed to still deliver the exec event, but
+  confirm the port is live for the `BRK` that follows the exec — (re)establish
+  after the exec-stop, before continuing to the exports-fetch point.
+- **Reply/resume protocol.** Returning the right `kern_return_t` from the
+  catch handler is what resumes the thread; a wrong reply hangs (no resume) or
+  double-resumes. Get `RetCode`/`MACH_RCV` semantics right.
+- **Forwarding.** For any exception that is *not* our `BRK` (unexpected fault),
+  forward to the task's previously-registered handler (save the old ports the
+  kernel returns when you install yours) so real faults aren't swallowed.
+- **`MACH_EXCEPTION_CODES`.** 64-bit codes; the MIG subsystem and the reply must
+  agree or you get parse/`MACH_RCV` errors.
+- **Entitlement.** No new entitlement — `PT_ATTACHEXC` needs the same
+  `com.apple.security.cs.debugger`/root the loader already has.
+- **Rosetta precedence.** The whole premise — *confirm empirically* on the runner
+  that the debugger port pre-empts libRosettaRuntime's handler (see below).
+
+---
+
+## Complementary / cheaper fix — delete the breakpoint
+
+The single `BRK` exists only to read `X19` = Exports struct address at a known
+point in libRosettaRuntime init (`main.cpp:725-733`). The loader **already**
+computes `translate_insn`'s live address *without* a trap, from
+`init_library`'s runtime address (first `x87Exports[]` entry) plus an RVA delta
+(`main.cpp:816-839`). If the Exports address is similarly derivable from
+offsets/exports without stopping at `exports_fetch`, the planted breakpoint —
+and thus the crash's prime suspect — disappears, leaving only the exec-stop.
+This is smaller than the full Mach-port migration and may be sufficient on its
+own; ideally do both (delete the BRK *and* move to an exception port so the
+exec-stop is also robust). Worth scoping first — it could be the 80/20.
+
+---
+
+## How to confirm the hypothesis (not locally reproducible)
+
+Since local runs never crash, confirmation needs a CI-like environment:
+
+1. **Instrument the setup path** on a CI branch: add loud logging (unconditional
+   `fprintf`, not `VERBOSE_LOG`) around each of: exec stop reached, breakpoint
+   set, breakpoint hit / `continueExecution` return, each `PT_CONTINUE` result,
+   `WSTOPSIG` value in `waitForStopped`. Re-run CI a few times; the last line
+   before the `exit=133` pins the exact trap. Prediction: it dies at/around the
+   `exports_fetch` breakpoint hit.
+2. **Cold-cache local repro attempt:** `sudo rm -rf /var/db/oah/*` (Rosetta AOT
+   cache) then run the suite under `sudo scripts/run_tests.sh` in a loop; try
+   under CPU load / `taskpolicy` to mimic VM jitter. If it reproduces, iterate
+   locally.
+3. **Cheap disproof of the fix direction (diagnostic probe only, not the fix):**
+   on a throwaway branch, keep `PT_ATTACH` but register a
+   `task_set_exception_ports(EXC_MASK_BREAKPOINT, …)` on the parent right after
+   the exec stop, and see if CI stops crashing. If it does, that is strong
+   evidence the precedence hypothesis is correct — proceed to the *real* fix
+   (full `PT_ATTACHEXC`). Do **not** ship this hybrid: `PT_ATTACH`'s signal path
+   and the hand-registered port both contend for the `BRK`, which is the
+   ambiguity the real fix removes.
+
+---
+
+## Verification plan for the fix
+
+- Local: `bash scripts/run_tests.sh --no-build` → 825/825 (must not regress).
+- Local soak: loop the suite (and with `X87_DISABLE_HOOK=1`, which also uses the
+  attach+detach path, `main.cpp:708-723`) many times; expect zero crashes.
+- CI: push branch; the runner (`sudo`) should go green and **stay** green across
+  repeated re-runs (the flakiness only shows at CI cadence, so re-run several
+  times, don't trust one green).
+- Confirm the steady-state IPC + profiling still works (a normal WoW capture per
+  the `howto-profile` memory) — the stub/detach path is untouched but the attach
+  refactor precedes it.
+
+---
+
+## Scope estimate
+
+- **Delete-the-breakpoint** route: small, localized to `main.cpp:725-733` +
+  offset discovery; low risk; may fully fix if the BRK is the sole trigger.
+- **Full `PT_ATTACHEXC`** route: medium; rewrites `MuhDebugger`'s ~5 trap methods
+  (`main.cpp:67-166`) and adds a small MIG/`mach_msg` exception handler; removes
+  `PT_ATTACH` + `waitpid`/`WSTOPSIG` entirely; touches the most delicate part of
+  the loader; needs the soak above. This is the durable, provably-correct fix,
+  the one the `main.cpp:106` comment already points to, and the architecturally
+  consistent end state (all-Mach loader).
+
+Recommended order: scope the breakpoint-deletion first (cheap, possibly
+sufficient on its own), then do the full `PT_ATTACHEXC` migration regardless — it
+makes the exec-stop robust too and permanently closes the signal-delivery race
+class, not just the one breakpoint. Do both; do not ship the retry band-aid or
+the `task_set_exception_ports` hybrid.
+
+---
+
+## Anchors
+
+- `.github/workflows/ci.yml:16,29` — Rosetta install + `sudo` test run.
+- `rosetta_loader/src/main.cpp:67` `waitForStopped`, `:100` `attach`,
+  `:130` `waitForExecStop`, `:148` `continueExecution`, `:159` `detach`,
+  `:168` `setBreakpoint`, `:548` `AARCH64_BREAKPOINT`, `:588-646` fork dance,
+  `:725-733` the one breakpoint, `:816-839` trap-free address computation,
+  `:1429-1473` detach + async steady state.
+- `rosetta_loader/src/stub_asm.cpp:366` — "libRosettaRuntime's `__TEXT` eats
+  `EXC_BREAKPOINT` before SIGTRAP is delivered" (the corroborating prior finding;
+  refs `feedback_brk_vs_svc_in_rosetta_text.md`, not in-repo).
+- `scripts/run_tests.sh:169-192` — `check_output` crash classification.

--- a/rosetta_loader/CMakeLists.txt
+++ b/rosetta_loader/CMakeLists.txt
@@ -1,10 +1,43 @@
+# Generate the MIG mach_exc exception server (message ids 2405-2407,
+# MACH_EXCEPTION_CODES) so the loader can receive ptrace debug events on a Mach
+# exception port instead of via the deprecated PT_ATTACH/waitpid signal path.
+# See src/mach_exception.cpp.
+execute_process(
+    COMMAND xcrun --sdk macosx --show-sdk-path
+    OUTPUT_VARIABLE MACOS_SDK_PATH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+set(MACH_EXC_SERVER "${CMAKE_CURRENT_BINARY_DIR}/mach_excServer.c")
+set(MACH_EXC_SHEADER "${CMAKE_CURRENT_BINARY_DIR}/mach_excServer.h")
+
+add_custom_command(
+    OUTPUT ${MACH_EXC_SERVER} ${MACH_EXC_SHEADER}
+    COMMAND xcrun mig
+            -arch arm64
+            -isysroot "${MACOS_SDK_PATH}"
+            -server ${MACH_EXC_SERVER}
+            -sheader ${MACH_EXC_SHEADER}
+            -user /dev/null
+            -header /dev/null
+            "${MACOS_SDK_PATH}/usr/include/mach/mach_exc.defs"
+    DEPENDS "${MACOS_SDK_PATH}/usr/include/mach/mach_exc.defs"
+    COMMENT "Generating MIG mach_exc exception server"
+    VERBATIM
+)
+
 add_executable(x87sidecar
     src/main.cpp
     src/macho_loader.cpp
+    src/mach_exception.cpp
     src/offset_finder.cpp
     src/sidecar.cpp
     src/stub_asm.cpp
+    ${MACH_EXC_SERVER}
 )
+
+# mach_exception.cpp includes the generated mach_excServer.h from the build dir.
+target_include_directories(x87sidecar PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 target_link_libraries(x87sidecar PRIVATE rosetta_core)
 

--- a/rosetta_loader/src/mach_exception.cpp
+++ b/rosetta_loader/src/mach_exception.cpp
@@ -1,0 +1,325 @@
+#include "mach_exception.hpp"
+
+#include <mach/mach.h>
+#include <mach/mig_errors.h>
+#include <sys/ptrace.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+
+// MIG-generated exception server (message ids 2405-2407, MACH_EXCEPTION_CODES).
+// Generated into the build dir from $SDK/usr/include/mach/mach_exc.defs by the
+// CMake mig step; declares mach_exc_server() and the catch_* routines below.
+// The generated server is C; force C linkage on its declarations so our
+// definitions below and the C-compiled server agree.
+extern "C" {
+#include "mach_excServer.h"
+}
+
+// The MIG server dispatches to plain-C catch_* functions by name. There is only
+// ever one debugger session in this process, so a file-static pointer is set
+// around each mach_exc_server() call (mirrors debugserver's g_message).
+static MachExceptionSession* g_activeSession = nullptr;
+
+extern "C" kern_return_t catch_mach_exception_raise(mach_port_t /*exception_port*/,
+                                                    mach_port_t thread, mach_port_t task,
+                                                    exception_type_t exception,
+                                                    mach_exception_data_t code,
+                                                    mach_msg_type_number_t codeCnt) {
+    if (g_activeSession != nullptr) {
+        // mach_exception_data_t is a 64-bit array; copy through int64_t so the
+        // header stays independent of MIG typedefs.
+        int64_t codes[2] = {0, 0};
+        const int n = codeCnt < 2 ? static_cast<int>(codeCnt) : 2;
+        for (int i = 0; i < n; ++i) {
+            std::memcpy(&codes[i], &code[i], sizeof(int64_t));
+        }
+        g_activeSession->recordFromCatch(thread, task, exception, codes, static_cast<int>(codeCnt));
+    }
+    // Return success so MIG builds a resume reply; we send it (or override its
+    // RetCode for forwarding) later, once we have acted on the stop.
+    return KERN_SUCCESS;
+}
+
+// EXCEPTION_DEFAULT delivers via catch_mach_exception_raise only; the state
+// variants are never invoked but must exist for the MIG server to link.
+extern "C" kern_return_t catch_mach_exception_raise_state(
+    mach_port_t /*exception_port*/, exception_type_t /*exception*/,
+    const mach_exception_data_t /*code*/, mach_msg_type_number_t /*codeCnt*/, int* /*flavor*/,
+    const thread_state_t /*old_state*/, mach_msg_type_number_t /*old_stateCnt*/,
+    thread_state_t /*new_state*/, mach_msg_type_number_t* /*new_stateCnt*/) {
+    return KERN_FAILURE;
+}
+
+extern "C" kern_return_t catch_mach_exception_raise_state_identity(
+    mach_port_t /*exception_port*/, mach_port_t /*thread*/, mach_port_t /*task*/,
+    exception_type_t /*exception*/, mach_exception_data_t /*code*/,
+    mach_msg_type_number_t /*codeCnt*/, int* /*flavor*/, thread_state_t /*old_state*/,
+    mach_msg_type_number_t /*old_stateCnt*/, thread_state_t /*new_state*/,
+    mach_msg_type_number_t* /*new_stateCnt*/) {
+    return KERN_FAILURE;
+}
+
+void MachExceptionSession::recordFromCatch(mach_port_t thread, mach_port_t task,
+                                           exception_type_t exception, const int64_t* code,
+                                           int codeCnt) {
+    current_.type = exception;
+    current_.thread = thread;
+    current_.task = task;
+    current_.codeCount = codeCnt < 2 ? codeCnt : 2;
+    current_.codes[0] = current_.codeCount > 0 ? code[0] : 0;
+    current_.codes[1] = current_.codeCount > 1 ? code[1] : 0;
+    current_.valid = true;
+}
+
+bool MachExceptionSession::swapPorts(task_t task) {
+    savedCount_ = kMaxExcPorts;
+    // Claim ONLY EXC_SOFTWARE at task level: it carries the ptrace signal-stops
+    // (attach/exec/SIGSTOP as EXC_SOFT_SIGNAL) that PT_ATTACHEXC folds into Mach
+    // exceptions and that we must receive. We deliberately do NOT claim
+    // EXC_BREAKPOINT here — that is libRosettaRuntime's task-level port for its
+    // JIT BRKs, and displacing-then-restoring it races the runtime (the
+    // post-detach SIGTRAP / exit=133 flake). Our own planted BRK is caught at
+    // THREAD level instead (installThreadBreakpoint). Taking EXC_MASK_ALL would
+    // likewise disturb handlers for faults we never plant (e.g. EXC_BAD_ACCESS).
+    kern_return_t kr = task_swap_exception_ports(
+        task, EXC_MASK_SOFTWARE, exceptionPort_, EXCEPTION_DEFAULT | MACH_EXCEPTION_CODES,
+        THREAD_STATE_NONE, savedMasks_, &savedCount_, savedPorts_, savedBehaviors_, savedFlavors_);
+    if (kr != KERN_SUCCESS) {
+        fprintf(stdout, "MachExc: task_swap_exception_ports failed (0x%x: %s)\n", kr,
+                mach_error_string(kr));
+        savedCount_ = 0;
+        return false;
+    }
+    task_ = task;
+    haveSaved_ = true;
+    return true;
+}
+
+bool MachExceptionSession::install(pid_t pid, task_t task) {
+    pid_ = pid;
+
+    mach_port_t self = mach_task_self();
+    kern_return_t kr = mach_port_allocate(self, MACH_PORT_RIGHT_RECEIVE, &exceptionPort_);
+    if (kr != KERN_SUCCESS) {
+        fprintf(stdout, "MachExc: mach_port_allocate failed (0x%x: %s)\n", kr,
+                mach_error_string(kr));
+        return false;
+    }
+    kr = mach_port_insert_right(self, exceptionPort_, exceptionPort_, MACH_MSG_TYPE_MAKE_SEND);
+    if (kr != KERN_SUCCESS) {
+        fprintf(stdout, "MachExc: mach_port_insert_right failed (0x%x: %s)\n", kr,
+                mach_error_string(kr));
+        return false;
+    }
+    return swapPorts(task);
+}
+
+bool MachExceptionSession::reinstall(task_t task) {
+    if (exceptionPort_ == MACH_PORT_NULL) {
+        fprintf(stdout, "MachExc: reinstall before install\n");
+        return false;
+    }
+    task_ = task;
+    // If exec preserved our registration, don't swap again: task_swap would
+    // then record our own port as the "previous" handler and corrupt the
+    // restore. Only re-register when exec reset the task's exception ports.
+    if (verifyInstalled()) {
+        return true;
+    }
+    return swapPorts(task);
+}
+
+bool MachExceptionSession::verifyInstalled() const {
+    exception_mask_t masks[kMaxExcPorts];
+    mach_port_t ports[kMaxExcPorts];
+    exception_behavior_t behaviors[kMaxExcPorts];
+    thread_state_flavor_t flavors[kMaxExcPorts];
+    mach_msg_type_number_t count = kMaxExcPorts;
+    kern_return_t kr = task_get_exception_ports(task_, EXC_MASK_ALL, masks, &count, ports, behaviors,
+                                                flavors);
+    if (kr != KERN_SUCCESS) {
+        fprintf(stdout, "MachExc: task_get_exception_ports failed (0x%x: %s)\n", kr,
+                mach_error_string(kr));
+        return false;
+    }
+    for (mach_msg_type_number_t i = 0; i < count; ++i) {
+        if (ports[i] == exceptionPort_) {
+            return true;
+        }
+    }
+    // Not an error on its own: reinstall() uses this to decide whether exec
+    // reset the ports. Callers that require our port log their own failure.
+    return false;
+}
+
+bool MachExceptionSession::installThreadBreakpoint(thread_act_t thread) {
+    if (exceptionPort_ == MACH_PORT_NULL) {
+        fprintf(stdout, "MachExc: installThreadBreakpoint before install\n");
+        return false;
+    }
+    savedThreadCount_ = kMaxExcPorts;
+    kern_return_t kr = thread_swap_exception_ports(
+        thread, EXC_MASK_BREAKPOINT, exceptionPort_, EXCEPTION_DEFAULT | MACH_EXCEPTION_CODES,
+        THREAD_STATE_NONE, savedThreadMasks_, &savedThreadCount_, savedThreadPorts_,
+        savedThreadBehaviors_, savedThreadFlavors_);
+    if (kr != KERN_SUCCESS) {
+        fprintf(stdout, "MachExc: thread_swap_exception_ports failed (0x%x: %s)\n", kr,
+                mach_error_string(kr));
+        savedThreadCount_ = 0;
+        return false;
+    }
+    bpThread_ = thread;
+    haveThreadBp_ = true;
+    return true;
+}
+
+void MachExceptionSession::removeThreadBreakpoint() {
+    if (!haveThreadBp_) {
+        return;
+    }
+    // Write back whatever the thread had before. A freshly-exec'd thread has no
+    // EXC_BREAKPOINT handler, so savedThreadCount_ is typically 0 and this loop
+    // restores the (empty) default — clearing our registration. We never
+    // touched the task-level handler, so there is nothing else to undo.
+    for (mach_msg_type_number_t i = 0; i < savedThreadCount_; ++i) {
+        thread_set_exception_ports(bpThread_, savedThreadMasks_[i], savedThreadPorts_[i],
+                                   savedThreadBehaviors_[i], savedThreadFlavors_[i]);
+    }
+    if (savedThreadCount_ == 0) {
+        // Nothing was registered before us: explicitly drop our port so the
+        // thread falls through to the task-level (Rosetta) handler again.
+        thread_set_exception_ports(bpThread_, EXC_MASK_BREAKPOINT, MACH_PORT_NULL,
+                                   EXCEPTION_DEFAULT | MACH_EXCEPTION_CODES, THREAD_STATE_NONE);
+    }
+    haveThreadBp_ = false;
+    savedThreadCount_ = 0;
+    bpThread_ = MACH_PORT_NULL;
+}
+
+MachExceptionSession::Event MachExceptionSession::waitForEvent(uint32_t timeoutMs) {
+    current_ = Event{};
+    std::memset(&excMsg_, 0, sizeof(excMsg_));
+    std::memset(&replyMsg_, 0, sizeof(replyMsg_));
+
+    kern_return_t kr = mach_msg(&excMsg_.hdr, MACH_RCV_MSG | MACH_RCV_TIMEOUT, 0, sizeof(excMsg_),
+                                exceptionPort_, timeoutMs, MACH_PORT_NULL);
+    if (kr != KERN_SUCCESS) {
+        if (kr == MACH_RCV_TIMED_OUT) {
+            fprintf(stdout, "MachExc: timed out waiting for exception (%u ms)\n", timeoutMs);
+        } else {
+            fprintf(stdout, "MachExc: mach_msg receive failed (0x%x: %s)\n", kr,
+                    mach_error_string(kr));
+        }
+        return current_;  // valid == false
+    }
+
+    // Decode + build the reply. mach_exc_server invokes catch_mach_exception_raise
+    // (which fills current_ via recordFromCatch) and writes the reply into
+    // replyMsg_ without sending it — so the tracee stays stopped.
+    g_activeSession = this;
+    boolean_t handled = mach_exc_server(&excMsg_.hdr, &replyMsg_.hdr);
+    g_activeSession = nullptr;
+    if (!handled) {
+        fprintf(stdout, "MachExc: mach_exc_server did not handle the message (id=%d)\n",
+                excMsg_.hdr.msgh_id);
+        current_.valid = false;
+        return current_;
+    }
+    haveHeld_ = true;
+    return current_;
+}
+
+bool MachExceptionSession::sendReply() {
+    kern_return_t kr = mach_msg(&replyMsg_.hdr, MACH_SEND_MSG, replyMsg_.hdr.msgh_size, 0,
+                                MACH_PORT_NULL, MACH_MSG_TIMEOUT_NONE, MACH_PORT_NULL);
+    if (kr != KERN_SUCCESS) {
+        fprintf(stdout, "MachExc: mach_msg reply send failed (0x%x: %s)\n", kr,
+                mach_error_string(kr));
+        return false;
+    }
+    haveHeld_ = false;
+    return true;
+}
+
+bool MachExceptionSession::reply(int signalToForward) {
+    if (!haveHeld_) {
+        return true;  // nothing outstanding
+    }
+    // For a soft-signal stop, PT_THUPDATE selects the signal delivered to the
+    // tracee on resume (0 suppresses it — the attach SIGSTOP and exec SIGTRAP
+    // are pure stops we never want re-delivered). Breakpoint stops carry no
+    // signal, so this is skipped for them.
+    if (current_.softSignal() != 0) {
+        errno = 0;
+        if (ptrace(PT_THUPDATE, pid_, reinterpret_cast<caddr_t>(static_cast<uintptr_t>(
+                                           current_.thread)),
+                   signalToForward) != 0) {
+            fprintf(stdout, "MachExc: PT_THUPDATE failed: %s\n", strerror(errno));
+        }
+    }
+    return sendReply();
+}
+
+bool MachExceptionSession::release() {
+    if (!haveHeld_) {
+        return true;
+    }
+    return sendReply();
+}
+
+bool MachExceptionSession::forward() {
+    if (!haveHeld_) {
+        return true;
+    }
+    // Flip the reply RetCode so the kernel treats the exception as unhandled by
+    // us and applies its default disposition. mach_exception_raise's reply is a
+    // mig_reply_error_t (Head, NDR, RetCode).
+    auto* err = reinterpret_cast<mig_reply_error_t*>(&replyMsg_);
+    err->RetCode = KERN_FAILURE;
+    fprintf(stdout, "MachExc: forwarding unhandled exception type=%d to default disposition\n",
+            current_.type);
+    return sendReply();
+}
+
+void MachExceptionSession::restoreAndTearDown() {
+    // Drop any thread-level EXC_BREAKPOINT registration first (normally already
+    // removed right after the BRK; this is a safety net for error paths).
+    removeThreadBreakpoint();
+    if (haveSaved_ && task_ != TASK_NULL) {
+        for (mach_msg_type_number_t i = 0; i < savedCount_; ++i) {
+            // We now only ever hold EXC_MASK_SOFTWARE at task level, but keep
+            // the conditional restore: write the saved handler back ONLY if we
+            // are still the registered handler for this mask. If libRosettaRuntime
+            // has installed its own handler over ours since the swap, blindly
+            // writing back our stale (empty) snapshot would clobber it; leave
+            // the runtime's handler in place instead.
+            exception_mask_t curMasks[kMaxExcPorts];
+            mach_port_t curPorts[kMaxExcPorts];
+            exception_behavior_t curBehaviors[kMaxExcPorts];
+            thread_state_flavor_t curFlavors[kMaxExcPorts];
+            mach_msg_type_number_t curCount = kMaxExcPorts;
+            bool stillOurs = false;
+            if (task_get_exception_ports(task_, savedMasks_[i], curMasks, &curCount, curPorts,
+                                         curBehaviors, curFlavors) == KERN_SUCCESS) {
+                for (mach_msg_type_number_t j = 0; j < curCount; ++j) {
+                    if (curPorts[j] == exceptionPort_) {
+                        stillOurs = true;
+                        break;
+                    }
+                }
+            }
+            if (stillOurs) {
+                task_set_exception_ports(task_, savedMasks_[i], savedPorts_[i], savedBehaviors_[i],
+                                         savedFlavors_[i]);
+            }
+        }
+        haveSaved_ = false;
+        savedCount_ = 0;
+    }
+    if (exceptionPort_ != MACH_PORT_NULL) {
+        mach_port_deallocate(mach_task_self(), exceptionPort_);
+        exceptionPort_ = MACH_PORT_NULL;
+    }
+}

--- a/rosetta_loader/src/mach_exception.hpp
+++ b/rosetta_loader/src/mach_exception.hpp
@@ -1,0 +1,159 @@
+#ifndef X87SIDECAR_MACH_EXCEPTION_HPP
+#define X87SIDECAR_MACH_EXCEPTION_HPP
+
+#include <mach/mach.h>
+#include <sys/types.h>
+
+#include <cstdint>
+
+// MachExceptionSession — receive the loader's ptrace debug events (attach-stop,
+// exec-stop and the one planted BRK) as Mach exception messages on a port WE
+// own, instead of as BSD signals via waitpid/WSTOPSIG.
+//
+// Why this exists: the loader attaches with ptrace(PT_ATTACHEXC) rather than the
+// deprecated PT_ATTACH. PT_ATTACHEXC routes every debug event to a Mach
+// exception port. A debugger-owned exception port takes precedence over the
+// target's own handlers, so libRosettaRuntime's __TEXT EXC_BREAKPOINT handling
+// can no longer win the race and let our planted BRK leak to the parent as a
+// fatal SIGTRAP (the CI `exit=133` flake — see
+// docs/investigations/ci-flaky-sigtrap-attach.md). An event delivered as a Mach
+// message to our port structurally cannot fall through to the tracee's default
+// (fatal) signal disposition.
+//
+// Model on lldb debugserver's MachException/MachTask. This class is a small,
+// synchronous, single-session variant: the loader's setup runs on one thread
+// and there is only ever one tracee, so there is no separate exception thread
+// and no locking. Holding an unreplied exception message == "tracee stopped";
+// replying == "continue".
+class MachExceptionSession {
+public:
+    // Decoded exception message. Not replied to yet — while an event is
+    // outstanding the faulting thread is stopped in the kernel awaiting our
+    // reply.
+    struct Event {
+        exception_type_t type = 0;
+        mach_port_t thread = MACH_PORT_NULL;
+        mach_port_t task = MACH_PORT_NULL;
+        int64_t codes[2] = {0, 0};
+        int codeCount = 0;
+        bool valid = false;
+
+        // The BSD signal folded into an EXC_SOFTWARE/EXC_SOFT_SIGNAL, or 0.
+        // Attach-stop surfaces as SIGSTOP, exec-stop as SIGTRAP.
+        [[nodiscard]] int softSignal() const {
+            if (type == EXC_SOFTWARE && codeCount == 2 && codes[0] == EXC_SOFT_SIGNAL) {
+                return static_cast<int>(codes[1]);
+            }
+            return 0;
+        }
+        [[nodiscard]] bool isBreakpoint() const { return type == EXC_BREAKPOINT; }
+    };
+
+    // Allocate a receive right, insert a send right, and atomically install our
+    // port as the task's EXC_MASK_SOFTWARE handler (EXCEPTION_DEFAULT |
+    // MACH_EXCEPTION_CODES), saving the previous ports for restore/forward. We
+    // claim only EXC_SOFTWARE at task level: PT_ATTACHEXC folds the ptrace
+    // signal-stops (attach/exec/SIGSTOP) into EXC_SOFT_SIGNAL, which we must
+    // receive. The one planted BRK (EXC_BREAKPOINT) is caught at THREAD level
+    // instead (see installThreadBreakpoint) so we never share the task-level
+    // EXC_BREAKPOINT port with libRosettaRuntime's JIT.
+    // pid is the tracee pid (needed for PT_THUPDATE on reply).
+    bool install(pid_t pid, task_t task);
+
+    // Re-install on a (possibly new) task port. execve resets a task's
+    // exception ports, so this must run after the exec-stop and before the BRK.
+    bool reinstall(task_t task);
+
+    // True if our port is currently among the task's registered handlers.
+    // Used to prove the port is live before continuing into the BRK window.
+    [[nodiscard]] bool verifyInstalled() const;
+
+    // Register our exception port for EXC_BREAKPOINT on a SINGLE thread (the one
+    // that will execute the planted BRK) instead of at task level. Thread-level
+    // exception ports out-rank task-level ones in Mach's delivery order, so we
+    // still catch our own BRK — but libRosettaRuntime's task-level
+    // EXC_BREAKPOINT handler (used by its JIT) is never displaced, so there is
+    // nothing to restore and no clobber race at detach (the ~1/12 post-detach
+    // SIGTRAP / exit=133 flake). The BRK arrives on the same receive port as the
+    // soft-signal stops; catch_mach_exception_raise dispatches by type.
+    bool installThreadBreakpoint(thread_act_t thread);
+
+    // Tear down the thread-level EXC_BREAKPOINT registration installed above,
+    // restoring whatever the thread had before (freshly-exec'd threads have no
+    // handler, so this clears ours). Idempotent.
+    void removeThreadBreakpoint();
+
+    // Block until an exception message arrives (or timeout). Runs the MIG
+    // server, which decodes the message and builds the reply we will later
+    // send. The returned Event is left UNREPLIED (the faulting thread stays
+    // blocked in the kernel awaiting our reply).
+    Event waitForEvent(uint32_t timeoutMs = 30000);
+
+    // Send the reply for the held event, releasing the faulting thread. For a
+    // soft-signal stop, PT_THUPDATE first forwards `signalToForward` to the
+    // tracee (0 == suppress, matching the old suppress-and-continue path).
+    bool reply(int signalToForward = 0);
+
+    // Reply "not handled" (KERN_FAILURE) for the held event so a genuine,
+    // unexpected fault takes its default disposition instead of being swallowed
+    // by a resume-reply. Only our own attach/exec/BRK events are ever replied
+    // with success.
+    bool forward();
+
+    // Send the reply message alone (no PT_THUPDATE), unblocking the faulting
+    // thread from the exception. Used to release the tracee AFTER PT_DETACH,
+    // when ptrace can no longer be called on it.
+    bool release();
+
+    // Restore the task's original exception ports and release our rights.
+    void restoreAndTearDown();
+
+    ~MachExceptionSession() { restoreAndTearDown(); }
+
+    // Called by the MIG-dispatched catch_mach_exception_raise trampoline to
+    // record the decoded event into the active session. Not for external use.
+    void recordFromCatch(mach_port_t thread, mach_port_t task, exception_type_t exception,
+                         const int64_t* code, int codeCnt);
+
+private:
+    bool swapPorts(task_t task);
+    bool sendReply();
+
+    static constexpr int kMaxExcPorts = 32;  // >= EXC_TYPES_COUNT
+
+    mach_port_t exceptionPort_ = MACH_PORT_NULL;
+    task_t task_ = TASK_NULL;
+    pid_t pid_ = -1;
+    bool haveHeld_ = false;
+
+    // Saved previous TASK-level exception ports (for restore / default
+    // forwarding). Covers EXC_MASK_SOFTWARE only.
+    exception_mask_t savedMasks_[kMaxExcPorts] = {};
+    mach_port_t savedPorts_[kMaxExcPorts] = {};
+    exception_behavior_t savedBehaviors_[kMaxExcPorts] = {};
+    thread_state_flavor_t savedFlavors_[kMaxExcPorts] = {};
+    mach_msg_type_number_t savedCount_ = 0;
+    bool haveSaved_ = false;
+
+    // Saved previous THREAD-level EXC_BREAKPOINT ports for the one thread we arm
+    // around the planted BRK (see installThreadBreakpoint/removeThreadBreakpoint).
+    exception_mask_t savedThreadMasks_[kMaxExcPorts] = {};
+    mach_port_t savedThreadPorts_[kMaxExcPorts] = {};
+    exception_behavior_t savedThreadBehaviors_[kMaxExcPorts] = {};
+    thread_state_flavor_t savedThreadFlavors_[kMaxExcPorts] = {};
+    mach_msg_type_number_t savedThreadCount_ = 0;
+    thread_act_t bpThread_ = MACH_PORT_NULL;
+    bool haveThreadBp_ = false;
+
+    // Message buffers. 1024 bytes comfortably holds a 64-bit exception message
+    // and its reply (mirrors debugserver's MachMessage union).
+    union Buffer {
+        mach_msg_header_t hdr;
+        char data[1024];
+    };
+    Buffer excMsg_{};
+    Buffer replyMsg_{};
+    Event current_{};
+};
+
+#endif  // X87SIDECAR_MACH_EXCEPTION_HPP

--- a/rosetta_loader/src/main.cpp
+++ b/rosetta_loader/src/main.cpp
@@ -1,6 +1,7 @@
 #include <mach-o/dyld.h>
 #include <mach-o/dyld_images.h>
 #include <mach/mach_vm.h>
+#include <mach/vm_attributes.h>
 #include <sched.h>
 #include <sys/event.h>
 #include <sys/mman.h>
@@ -10,6 +11,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cerrno>
+#include <csignal>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -23,6 +25,7 @@
 #include <utility>
 #include <vector>
 
+#include "mach_exception.hpp"
 #include "offset_finder.hpp"
 #include "rosetta_core/Config.h"
 #include "rosetta_core/ConfigEnv.h"
@@ -62,29 +65,77 @@ private:
     task_t taskPort_ = MACH_PORT_NULL;
     std::map<uint64_t, uint32_t> breakpoints_;  // addr -> original instruction
 
-    // Wait for the traced process to stop. If expectedSignal is non-zero,
-    // loop and suppress any other signals until the expected one arrives.
-    [[nodiscard]] bool waitForStopped(int expectedSignal = 0) const {
+    // Debug events arrive as Mach exception messages on a port we own (see
+    // mach_exception.hpp). While an event is held (unreplied) the tracee is
+    // stopped; replying resumes it. This replaces the PT_ATTACH +
+    // waitpid/WSTOPSIG signal path, whose EXC_BREAKPOINT delivery raced
+    // libRosettaRuntime's own handler and leaked our planted BRK to the parent
+    // as a fatal SIGTRAP (CI exit=133 — see
+    // docs/investigations/ci-flaky-sigtrap-attach.md).
+    MachExceptionSession exc_;
+    MachExceptionSession::Event lastEvent_{};
+
+    // Receive the next event, suppressing soft-signal stops other than
+    // expectedSignal (0 = return on any stop), mirroring the old
+    // suppress-and-continue loop. An EXC_BREAKPOINT is always a stop. An
+    // unexpected non-signal exception is a genuine fault: forward it to the
+    // task's default disposition and fail.
+    bool waitForStopped(int expectedSignal = 0) {
         while (true) {
-            int status;
-            if (waitpid(childPid_, &status, 0) == -1) {
-                fprintf(stdout, "waitpid: %s\n", strerror(errno));
+            lastEvent_ = exc_.waitForEvent();
+            if (!lastEvent_.valid) {
                 return false;
             }
-            if (!WIFSTOPPED(status)) {  // NOLINT(readability-simplify-boolean-expr)
-                return false;
-            }
-            int sig = WSTOPSIG(status);
-            VERBOSE_LOG("Process stopped signal=%d\n", sig);
-            if (expectedSignal == 0 || sig == expectedSignal) {
+            if (lastEvent_.isBreakpoint()) {
+                VERBOSE_LOG("Stopped at EXC_BREAKPOINT\n");
                 return true;
             }
-            // Spurious signal; suppress it and continue
-            VERBOSE_LOG("Suppressing unexpected signal %d (waiting for %d)\n", sig, expectedSignal);
-            if (ptrace(PT_CONTINUE, childPid_, reinterpret_cast<caddr_t>(1), 0) < 0) {
-                fprintf(stdout, "ptrace(PT_CONTINUE suppress): %s\n", strerror(errno));
+            int sig = lastEvent_.softSignal();
+            if (sig != 0) {
+                VERBOSE_LOG("Process stopped signal=%d\n", sig);
+                if (expectedSignal == 0 || sig == expectedSignal) {
+                    return true;
+                }
+                VERBOSE_LOG("Suppressing unexpected signal %d (waiting for %d)\n", sig,
+                            expectedSignal);
+                if (!exc_.reply(0)) {
+                    return false;
+                }
+                continue;
+            }
+            fprintf(stdout, "Unexpected exception type=%d during setup; forwarding\n",
+                    lastEvent_.type);
+            exc_.forward();
+            return false;
+        }
+    }
+
+    // Wait specifically for the planted BRK (EXC_BREAKPOINT), suppressing any
+    // soft signals that arrive first. The old code caught the BRK as a SIGTRAP
+    // via ptrace; under PT_ATTACHEXC a hardware breakpoint is delivered as
+    // EXC_BREAKPOINT directly.
+    bool waitForBreakpoint() {
+        while (true) {
+            lastEvent_ = exc_.waitForEvent();
+            if (!lastEvent_.valid) {
                 return false;
             }
+            if (lastEvent_.isBreakpoint()) {
+                VERBOSE_LOG("Stopped at EXC_BREAKPOINT\n");
+                return true;
+            }
+            int sig = lastEvent_.softSignal();
+            if (sig != 0) {
+                VERBOSE_LOG("Suppressing signal %d while waiting for breakpoint\n", sig);
+                if (!exc_.reply(0)) {
+                    return false;
+                }
+                continue;
+            }
+            fprintf(stdout, "Unexpected exception type=%d before breakpoint; forwarding\n",
+                    lastEvent_.type);
+            exc_.forward();
+            return false;
         }
     }
 
@@ -96,40 +147,55 @@ public:
     }
 
     [[nodiscard]] task_t taskPort() const { return taskPort_; }
+    [[nodiscard]] mach_port_t stoppedThread() const { return lastEvent_.thread; }
+
+    // Arm/disarm the thread-level EXC_BREAKPOINT catcher on the currently
+    // stopped thread — the one that will execute (and later re-execute) the
+    // planted BRK. Must be armed before continuing into the BRK and disarmed
+    // after the original instruction is restored. Catching the BRK at thread
+    // level keeps us off libRosettaRuntime's task-level EXC_BREAKPOINT port.
+    bool armThreadBreakpoint() { return exc_.installThreadBreakpoint(lastEvent_.thread); }
+    void disarmThreadBreakpoint() { exc_.removeThreadBreakpoint(); }
 
     bool attach(pid_t pid) {
         childPid_ = pid;
         VERBOSE_LOG("Attempting to attach to %d\n", childPid_);
 
-        // Attach to the target via PT_ATTACH (sends SIGSTOP).
-        //
-        // Apple deprecated PT_ATTACH in favour of PT_ATTACHEXC, which
-        // delivers stop notifications via a Mach exception port instead
-        // of as a signal.  Switching means rewriting waitForStopped() to
-        // pull from the exception port (waitpid + WIFSTOPPED won't see the
-        // stop), and getting that right across our entire attach flow is
-        // a bigger surgical change than is justified for an interface
-        // Apple has been threatening to remove for years without doing so.
-        // Suppress the warning locally and revisit if the symbol actually
-        // disappears.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        if (ptrace(PT_ATTACH, childPid_, nullptr, 0) == -1) {
-#pragma clang diagnostic pop
-            fprintf(stdout, "ptrace(PT_ATTACH): %s\n", strerror(errno));
+        // Grab the task port up front (pre-exec) so we can install our Mach
+        // exception port before attaching. The loader already holds the
+        // debugger entitlement / runs as root, and already task_for_pid's the
+        // harder post-exec Rosetta process below.
+        if (task_for_pid(mach_task_self(), childPid_, &taskPort_) != KERN_SUCCESS) {
+            fprintf(stdout, "attach: task_for_pid(%d) failed\n", childPid_);
             return false;
         }
-        if (!waitForStopped()) {
+        // Install the exception port BEFORE attaching so every debug event is
+        // routed to us and can never fall through to the parent's fatal signal
+        // disposition.
+        if (!exc_.install(childPid_, taskPort_)) {
             return false;
         }
-        VERBOSE_LOG("Attached to %d (SIGSTOP)\n", childPid_);
+        // PT_ATTACHEXC: a ptrace attach (sibling of PT_ATTACH) that delivers
+        // debug events as Mach exceptions to our port instead of as BSD
+        // signals. Sends SIGSTOP, delivered as EXC_SOFT_SIGNAL(SIGSTOP).
+        if (ptrace(PT_ATTACHEXC, childPid_, nullptr, 0) == -1) {
+            fprintf(stdout, "ptrace(PT_ATTACHEXC): %s\n", strerror(errno));
+            return false;
+        }
+        if (!waitForStopped()) {  // consume the attach-stop
+            return false;
+        }
+        VERBOSE_LOG("Attached to %d (attach-stop)\n", childPid_);
         return true;
     }
 
-    // Continue the traced process and wait for it to stop at execv (SIGTRAP).
+    // Resume from the attach-stop, let the parent execv, and stop at the exec
+    // SIGTRAP. execve can hand back a different task port and resets thread
+    // state, so re-fetch the task port and make sure our exception port covers
+    // the post-exec task before the breakpoint window.
     bool waitForExecStop() {
-        if (ptrace(PT_CONTINUE, childPid_, reinterpret_cast<caddr_t>(1), 0) < 0) {
-            fprintf(stdout, "ptrace(PT_CONTINUE for exec): %s\n", strerror(errno));
+        if (!exc_.reply(0)) {  // resume, suppressing SIGSTOP
+            fprintf(stdout, "waitForExecStop: failed to resume from attach-stop\n");
             return false;
         }
         if (!waitForStopped(SIGTRAP)) {
@@ -141,28 +207,60 @@ public:
             fprintf(stdout, "Failed to get task port for pid %d\n", childPid_);
             return false;
         }
+        if (!exc_.reinstall(taskPort_) || !exc_.verifyInstalled()) {
+            fprintf(stdout, "Failed to (re)install exception port after exec\n");
+            return false;
+        }
         VERBOSE_LOG("Started debugging process %d using port %d\n", childPid_, taskPort_);
         return true;
     }
 
     bool continueExecution() {
-        if (ptrace(PT_CONTINUE, childPid_, reinterpret_cast<caddr_t>(1), 0) < 0) {
-            fprintf(stdout, "ptrace(PT_CONTINUE): %s\n", strerror(errno));
+        if (!exc_.reply(0)) {  // resume from the held stop
+            fprintf(stdout, "continueExecution: resume failed\n");
             return false;
         }
-
         VERBOSE_LOG("continueExecution...\n");
-
-        return waitForStopped(SIGTRAP);
+        // ARM64 BRK does not advance PC; removeBreakpoint restores the original
+        // instruction, so replying (in detach) later re-executes it correctly.
+        return waitForBreakpoint();
     }
 
-    [[nodiscard]] bool detach() const {
-        if (ptrace(PT_DETACH, childPid_, reinterpret_cast<caddr_t>(1), 0) < 0) {
-            fprintf(stdout, "ptrace(PT_DETACH): %s\n", strerror(errno));
+    bool detach() {
+        // PT_DETACH requires the tracee to be in a BSD signal-stop. Under
+        // PT_ATTACHEXC our stops arrive as Mach exceptions (the BRK is a bare
+        // EXC_BREAKPOINT carrying no signal), which PT_DETACH rejects with
+        // EBUSY. So synthesize a SIGSTOP job-control stop to detach from — the
+        // approach debugserver takes in MachProcess::DoSIGSTOP/Detach. SIGSTOP
+        // cannot be caught or ignored, so the process stays stopped until
+        // PT_DETACH continues it.
+        // Drive the tracee into a SIGSTOP job-control stop and hold it. SIGSTOP
+        // can't be caught or ignored, and PT_DETACH only accepts a held
+        // signal-stop like this one — a bare EXC_BREAKPOINT or a running
+        // process both give EBUSY.
+        kill(childPid_, SIGSTOP);
+        if (!exc_.reply(0)) {  // release the held stop; run into the SIGSTOP
             return false;
         }
-        VERBOSE_LOG("Debugger detached.\n");
-        return true;
+        if (!waitForStopped(SIGSTOP)) {
+            fprintf(stdout, "detach: failed to reach SIGSTOP stop\n");
+            return false;
+        }
+        // Restore the task's exception ports, PT_DETACH from the held SIGSTOP
+        // stop, then release the exception (unblocking the thread). Order
+        // matters: PT_DETACH must run while the SIGSTOP exception is still held,
+        // and the release must run after (ptrace is no longer valid post-detach).
+        exc_.restoreAndTearDown();
+        bool ok = true;
+        if (ptrace(PT_DETACH, childPid_, reinterpret_cast<caddr_t>(1), 0) < 0) {
+            fprintf(stdout, "ptrace(PT_DETACH): %s\n", strerror(errno));
+            ok = false;
+        }
+        exc_.release();
+        if (ok) {
+            VERBOSE_LOG("Debugger detached.\n");
+        }
+        return ok;
     }
 
     bool setBreakpoint(uint64_t address) {
@@ -263,62 +361,39 @@ public:
         CPSR
     };
 
-    [[nodiscard]] uint64_t readRegister(Register reg) const {
-        thread_act_port_array_t threadList;
-        mach_msg_type_number_t threadCount;
-
-        kern_return_t kr = task_threads(taskPort_, &threadList, &threadCount);
-        if (kr != KERN_SUCCESS) {
-            fprintf(stdout, "Failed to get threads (error 0x%x: %s)\n", kr, mach_error_string(kr));
-            return 0;
-        }
-
+    // Read a register from a specific thread port. Used to read X19 from the
+    // exact thread reported by the breakpoint exception message — correct even
+    // if libRosettaRuntime has spawned other threads by then (task_threads[0]
+    // is not guaranteed to be the one that hit the BRK).
+    [[nodiscard]] uint64_t readRegister(mach_port_t thread, Register reg) const {
         arm_thread_state64_t state;
         mach_msg_type_number_t count = ARM_THREAD_STATE64_COUNT;
-        kr = thread_get_state(threadList[0], ARM_THREAD_STATE64,
-                              reinterpret_cast<thread_state_t>(&state), &count);
-
+        kern_return_t kr = thread_get_state(thread, ARM_THREAD_STATE64,
+                                            reinterpret_cast<thread_state_t>(&state), &count);
         if (kr != KERN_SUCCESS) {
             fprintf(stdout, "Failed to get thread state (error 0x%x: %s)\n", kr,
                     mach_error_string(kr));
             return 0;
         }
 
-        uint64_t value = 0;
         if (reg >= X0 && reg <= X28) {
-            value = state.__x[reg];
-        } else {
-            switch (reg) {
-                case FP:
-                    value = state.__fp;
-                    break;
-                case LR:
-                    value = state.__lr;
-                    break;
-                case SP:
-                    value = state.__sp;
-                    break;
-                case PC:
-                    value = state.__pc;
-                    break;
-                case CPSR:
-                    value = state.__cpsr;
-                    break;
-                default: {
-                    fprintf(stdout, "Invalid register\n");
-                    return 0;
-                }
-            }
+            return state.__x[reg];
         }
-
-        // Cleanup
-        for (unsigned int i = 0; i < threadCount; i++) {
-            mach_port_deallocate(mach_task_self(), threadList[i]);
+        switch (reg) {
+            case FP:
+                return state.__fp;
+            case LR:
+                return state.__lr;
+            case SP:
+                return state.__sp;
+            case PC:
+                return state.__pc;
+            case CPSR:
+                return state.__cpsr;
+            default:
+                fprintf(stdout, "Invalid register\n");
+                return 0;
         }
-        vm_deallocate(mach_task_self(), reinterpret_cast<vm_address_t>(threadList),
-                      sizeof(thread_t) * threadCount);
-
-        return value;
     }
 
     [[nodiscard]] bool setRegister(Register reg, uint64_t value) const {
@@ -430,6 +505,26 @@ public:
             fprintf(stdout, "Failed to write memory at 0x%llx (error 0x%x: %s)\n", address, kr,
                     mach_error_string(kr));
             return false;
+        }
+
+        // Flush the target's instruction cache for the written range. ARM64 I/D
+        // caches are not coherent: mach_vm_write lands in the D-cache path only,
+        // so a core that has already executed (and cached) this line keeps
+        // running the stale bytes. That is fatal for the one breakpoint we plant
+        // at exports_fetch: we plant a BRK, catch it, restore the original
+        // instruction, then RESUME the held thread — which re-fetches the same
+        // PC (ARM64 BRK does not advance PC). If the stale BRK is still in the
+        // I-cache at that re-fetch, it re-traps after we have detached and torn
+        // down our exception handler → an unhandled SIGTRAP kills the tracee
+        // (the flaky post-detach exit=133). Flushing here makes the restore (and
+        // every M2 __TEXT patch) coherent, exactly as lldb's debugserver does
+        // after writing to a tracee. Best-effort: a failure only regresses to
+        // the old behaviour, so log and continue.
+        vm_machine_attribute_val_t flush = MATTR_VAL_ICACHE_FLUSH;
+        kern_return_t fkr = mach_vm_machine_attribute(taskPort_, address, size, MATTR_CACHE, &flush);
+        if (fkr != KERN_SUCCESS) {
+            fprintf(stdout, "Warning: i-cache flush at 0x%llx failed (error 0x%x: %s)\n", address,
+                    fkr, mach_error_string(fkr));
         }
 
         return true;
@@ -722,11 +817,26 @@ int main(int argc, char* argv[]) try {
         return 0;
     }
 
+    // Catch the one planted BRK at THREAD level on the currently stopped thread
+    // (the single init thread that will execute exports_fetch). Thread-level
+    // exception ports out-rank task-level ones, so we still receive the BRK, but
+    // we never displace libRosettaRuntime's task-level EXC_BREAKPOINT handler —
+    // eliminating the detach-time restore race that leaked a fatal SIGTRAP to
+    // the parent (CI exit=133). Must be armed before continuing into the BRK.
+    if (!dbg.armThreadBreakpoint()) {
+        fprintf(stdout, "Failed to arm thread-level breakpoint catcher\n");
+        return 1;
+    }
     dbg.setBreakpoint(runtimeBase + offsetFinder.offsetExportsFetch_);
     dbg.continueExecution();
+    // Read X19 (Exports struct addr) from the thread that hit the BRK, then
+    // restore the original instruction and drop the thread-level catcher. The
+    // process stays stopped (we hold the breakpoint exception reply) through the
+    // M2 stub install below until detach.
+    auto rosettaRuntimeExportsAddress =
+        dbg.readRegister(dbg.stoppedThread(), MuhDebugger::Register::X19);
     dbg.removeBreakpoint(runtimeBase + offsetFinder.offsetExportsFetch_);
-
-    auto rosettaRuntimeExportsAddress = dbg.readRegister(MuhDebugger::Register::X19);
+    dbg.disarmThreadBreakpoint();
     VERBOSE_LOG("Rosetta runtime exports: 0x%llx\n", rosettaRuntimeExportsAddress);
 
     Exports exports;


### PR DESCRIPTION
## What

Migrates the loader's debug-attach from the deprecated `PT_ATTACH` +
`waitpid`/`WSTOPSIG` signal path to `PT_ATTACHEXC` + a Mach exception port
(`MachExceptionSession`), and fixes the flaky `SIGTRAP`/`exit=133` that has made
CI red since PR #7.

## Why the crash happened

The residual flake was **not** exception-port precedence — it was a missing
instruction-cache flush. ARM64 I/D caches are not coherent, and `writeMemory`
was a bare `mach_vm_write`. The loader plants a `BRK` at `exports_fetch`, the
thread executes it there once (caching the line), we restore the original
instruction (D-cache only) and resume the held thread — which re-fetches the
same PC (ARM64 `BRK` does not advance PC). If the stale `BRK` line survives in
the I-cache, it re-traps *after* we've detached and torn down our handler → an
unhandled `SIGTRAP` kills the tracee.

Every `EXC_BREAKPOINT` crash report (`~/Library/Logs/DiagnosticReports/`) faulted
at `libRosettaRuntime_base + exports_fetch`, which pinned it. Flaky ~1/12 =
whether the cache line was evicted before the re-fetch; independent of exception
port level (which is why moving the BRK catch to thread level alone didn't fix
it).

## Changes

- **`PT_ATTACHEXC` migration** — attach/exec/SIGSTOP stops arrive as
  `EXC_SOFT_SIGNAL`, the planted `BRK` as `EXC_BREAKPOINT`, on a port we own;
  `detach()` drives a held BSD `SIGSTOP` job-control stop (a held Mach exception
  / running / `task_suspend`ed tracee all give `EBUSY` on `PT_DETACH`).
- **The fix** — `writeMemory` now issues
  `mach_vm_machine_attribute(MATTR_CACHE, MATTR_VAL_ICACHE_FLUSH)` after each
  write, so the breakpoint restore and every M2 `__TEXT` patch are coherent (as
  lldb `debugserver` does).
- **Hardening** — catch the setup `BRK` at thread level
  (`thread_swap_exception_ports` on the single init thread) rather than task
  level, so we never share libRosettaRuntime's task-level `EXC_BREAKPOINT` port;
  the task-level claim is narrowed to `EXC_MASK_SOFTWARE` with a conditional
  restore.

## Verification

- `run_tests.sh` → 825/825 per run.
- **80/80 full-suite serial runs with zero crashes and zero new crash reports**
  (prior flake rate ~1/12; the loop was the only way to reproduce — it does not
  reproduce per-test in isolation).

Root-cause writeup: `docs/investigations/ci-flaky-sigtrap-attach.md`.
