### PR TITLE
loader: cut translate-path syscalls from 7 to 5 per request

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ So the fix is to keep all of our ARM64 code out of the Rosetta'd process entirel
 └──────────────────────────────────────────────────────────────────────────┘
 ```
 
-This is not free. Every cold-translated x87 block now pays a Mach IPC round-trip plus 4-6 `mach_vm_read` / `mach_vm_write` syscalls (for the IR buffer, insn buffer, and translation-result struct) that the in-process dylib didn't pay. Once stock has installed the ARM64 bytes the sidecar is off the hot path, so steady-state execution speed is unaffected, but cold translation is slower than it used to be. Profile counters are already `mach_vm_remap`'d (copy=FALSE) so JIT-emitted `LDADDAL` on a parent VA hits the same backing page the sidecar reads; doing the same for the IR / insn / TR buffers is a planned change to claw back the per-call syscalls.
+This is not free. Every cold-translated x87 block pays a Mach IPC round-trip that the in-process dylib didn't pay. Once stock has installed the ARM64 bytes the sidecar is off the hot path, so steady-state execution speed is unaffected; the remaining cost is cold-translation latency, and most of the per-request syscalls that used to accompany the round-trip have been clawed back. The sidecar caches the block's IR array across requests (revalidated with an 80-byte probe read, since one block generates one request per x87 run), caches the thread-context-offsets struct, and fuses the reply send with the next request receive into a single `mach_msg` trap. `X87_NO_TCO_CACHE` and `X87_NO_IR_CACHE` switch the caches back off. One tempting further step does not work and was reverted after testing: `mach_vm_remap`ing (copy=FALSE) the tracee's TR / output buffers into the sidecar so the remaining reads and writes become memcpys. The tracee is an x86_64-translated task with 4 KB VM pages, and remapping its private anonymous memory into the sidecar's 16 KB arm64 map silently degrades to copy semantics: the two views diverge in both directions. Sharing works only in the opposite direction, for pages the sidecar allocates and remaps into the tracee, which is exactly how the profile counter array is wired.
 
 In exchange, the sidecar is a normal arm64 process, free to use the C++ standard library and any arm64 dependencies. The in-process dylib had to stay close to no-std discipline: every call from our `__TEXT` into a library increased the wall-clock fraction the parent thread spent with its PC inside our pages, and with it the rate of the reverse-lookup panic. Out of process, that constraint is gone.
 
@@ -131,6 +131,7 @@ Knobs are environment variables read at startup. The most useful ones:
 | `X87_DISABLE_ALL_FUSIONS=1` | Disable all instruction fusions |
 | `X87_DISABLE_FUSIONS=f1,f2,…` | Disable specific fusions |
 | `X87_DISABLE_HOOK=1` | Skip the `translate_insn` patch (apples-to-apples baseline against stock Rosetta) |
+| `X87_NO_TCO_CACHE=1` / `X87_NO_IR_CACHE=1` | Disable the sidecar's per-request syscall optimizations (ThreadContextOffsets cache, per-block IR cache); A/B and bisect hatches |
 | `X87_LOGS=1` | Verbose loader logging |
 
 ## License

--- a/rosetta_core/include/rosetta_core/Config.h
+++ b/rosetta_core/include/rosetta_core/Config.h
@@ -211,6 +211,14 @@ struct RosettaConfig {
                                     //                  bad encoding can be found by
                                     //                  disassembling the dump offline.
                                     //                  EXTREMELY high volume.
+    uint8_t loader_no_tco_cache;    // X87_NO_TCO_CACHE  disable the per-pointer
+                                    //                  ThreadContextOffsets cache; re-read the
+                                    //                  24-byte struct from the tracee on every
+                                    //                  request (pre-optimization behaviour).
+    uint8_t loader_no_ir_cache;     // X87_NO_IR_CACHE  disable the per-block IR array cache;
+                                    //                  re-read the full 80 B x num_instrs IR
+                                    //                  array from the tracee on every request
+                                    //                  (pre-optimization behaviour).
 
     // X87_PROFILE=<path>  When non-empty, sidecar appends a binary
     // record per first-seen IRBlock to this file (full IR stream).

--- a/rosetta_core/src/ConfigEnv.cpp
+++ b/rosetta_core/src/ConfigEnv.cpp
@@ -268,6 +268,8 @@ RosettaConfig load_config_from_env() {
     cfg.loader_log_ops = env_truthy("X87_LOG_OPS") ? 1 : 0;
     cfg.loader_log_throughput = env_truthy("X87_LOG_THROUGHPUT") ? 1 : 0;
     cfg.loader_dump_emit = env_truthy("X87_DUMP_EMIT") ? 1 : 0;
+    cfg.loader_no_tco_cache = env_truthy("X87_NO_TCO_CACHE") ? 1 : 0;
+    cfg.loader_no_ir_cache = env_truthy("X87_NO_IR_CACHE") ? 1 : 0;
 
     if (const char* p = std::getenv("X87_PROFILE"); p != nullptr && p[0] != '\0') {
         cfg.profile_path = p;
@@ -303,6 +305,12 @@ void print_env_help(std::FILE* out) {
         "                                req/s every 2 s + an idle-transition line.\n"
         "                                Off by default; enable when telling 'stuck'\n"
         "                                apart from 'just slow' on long workloads.\n"
+        "  X87_NO_TCO_CACHE=1            disable the ThreadContextOffsets cache;\n"
+        "                                re-read the struct from the tracee on every\n"
+        "                                request (A/B / bisect hatch)\n"
+        "  X87_NO_IR_CACHE=1             disable the per-block IR array cache;\n"
+        "                                re-read the full IR array from the tracee on\n"
+        "                                every request (A/B / bisect hatch)\n"
         "  X87_DISABLE_CACHE=1           drop the cross-instruction GPR cache\n"
         "  X87_FAST_ROUND=1              skip RC dispatch; always emit FCVTNS/FRINTN\n"
         "                                (round-to-nearest only — UNSAFE for code that\n"

--- a/rosetta_loader/src/sidecar.cpp
+++ b/rosetta_loader/src/sidecar.cpp
@@ -59,6 +59,14 @@ struct ThreadArgs {
 // big workloads (e.g. WoW world-load) churn through cold translation.
 std::atomic<uint64_t> g_hits{0};
 
+// Translate-path syscall-optimization counters, read by the reporter.  All
+// writers are the single receive thread; atomics only because the reporter
+// thread reads them.
+std::atomic<uint64_t> g_statVmSyscalls{0};  // mach_vm_* traps on the translate path
+std::atomic<uint64_t> g_statTcoHits{0};     // TCO served from cache
+std::atomic<uint64_t> g_statIrHits{0};      // IR array served from cache (probe read only)
+std::atomic<uint64_t> g_statIrMisses{0};    // IR array read in full
+
 // X87_PROFILE state.  Opened once at sidecar startup; closed when the
 // receive thread exits (i.e. parent process death).  Block-id assignment
 // and de-dup live in profile::register_block (rosetta_core) so the JIT
@@ -196,6 +204,49 @@ static_assert(kStockTRSize <= offsetof(TranslationResult, x87_cache),
               "stock TR size must not exceed our struct's pre-x87_cache prefix");
 std::mutex g_x87CacheMu;
 std::unordered_map<uint64_t, X87Cache> g_x87Cache;
+
+// ThreadContextOffsets cache, keyed by the tracee-side pointer.  The struct
+// describes stock's thread-context layout (process-lifetime constants that
+// stock re-materialises on the calling thread's STACK, so the same pointer
+// recurs per thread with the same contents).  Each distinct pointer is read
+// from the tracee once; every miss cross-checks the new read against the
+// first cached copy and logs loudly if the constants assumption ever breaks.
+// Receive thread only, no lock.  X87_NO_TCO_CACHE restores the
+// read-every-request behaviour.
+std::unordered_map<uint64_t, ThreadContextOffsets> g_tcoCache;
+
+// Per-block IR array cache, keyed by TR address (one in-flight block per TR,
+// same keying rationale as g_x87Cache above).  The translator never mutates
+// the tracee's IR array (TranslatorX87Fusion works on a local copy), so it is
+// read-only cross-task and constant while stock walks the block.  But stock
+// walks it with one request per x87 run, and re-reading the whole array
+// (80 B × num_instrs) on every request was the single largest read on the
+// translate path.  Reuse requires the identity triple to match, the walk to
+// stay monotonic (a new translation pass restarts at a lower-or-equal index),
+// and an 80-byte probe of the current IRInstr to compare equal.  Residual
+// ABA needs recycled block/array pointers with a byte-identical current
+// IRInstr (incl. guest pc) but different lookahead entries, i.e. guest
+// self-modifying code re-decoded at the same pc: accepted, X87_NO_IR_CACHE
+// is the hatch.  Entry storage is reused across requests either way, which
+// also drops the old per-request vector malloc.  Receive thread only.
+struct IRCacheEntry {
+    uint64_t block = 0;
+    uint64_t instr_array = 0;
+    uint64_t num_instrs = 0;
+    uint64_t last_idx = 0;
+    std::vector<IRInstr> ir;
+};
+std::unordered_map<uint64_t, IRCacheEntry> g_irCache;
+
+// NOTE on the road not taken: mach_vm_remap(copy=FALSE) of TRACEE-owned pages
+// into the sidecar (to turn the TR / insn-buf / fixup reads and writes below
+// into memcpys) does NOT work.  The tracee is an x86_64-translated task with
+// 4 KB VM pages; remapping its private anonymous memory into our 16 KB arm64
+// map silently degrades to copy semantics, so the two views diverge in BOTH
+// directions (verified empirically 2026-07: reads return remap-time bytes,
+// writes through the local view never reach the tracee).  Sharing only works
+// in the other direction, for objects WE allocate and remap INTO the tracee
+// (the X87_PROFILE counter array in main.cpp).  Don't re-attempt.
 
 struct TranslateRequest {
     uint64_t tr_addr;
@@ -1805,6 +1856,25 @@ bool writeParent(mach_port_t task, uint64_t addr, const void* src, size_t size) 
            KERN_SUCCESS;
 }
 
+// Translate-path wrappers around readParent/writeParent, kept separate so
+// the reporter's vm/req metric counts only this path (the sampler thread
+// calls readParent directly).
+bool readTranslate(mach_port_t task, uint64_t addr, void* dst, size_t size) {
+    if (size == 0) {
+        return true;
+    }
+    g_statVmSyscalls.fetch_add(1, std::memory_order_relaxed);
+    return readParent(task, addr, dst, size);
+}
+
+bool writeTranslate(mach_port_t task, uint64_t addr, const void* src, size_t size) {
+    if (size == 0) {
+        return true;
+    }
+    g_statVmSyscalls.fetch_add(1, std::memory_order_relaxed);
+    return writeParent(task, addr, src, size);
+}
+
 // Allocate a parent-side replacement buffer of size `newCap`, copy parent's
 // existing live bytes, then append `tailSize` bytes from `tail`. On success
 // returns the parent VA of the new buffer. On any failure deallocates and
@@ -1815,19 +1885,20 @@ mach_vm_address_t allocAndAppendInParent(mach_port_t parentTask, uint64_t origAd
     // Round up to page granularity.
     newCap = (newCap + 0xFFF) & ~static_cast<uint64_t>(0xFFF);
     mach_vm_address_t parentNew = 0;
+    g_statVmSyscalls.fetch_add(1, std::memory_order_relaxed);
     if (mach_vm_allocate(parentTask, &parentNew, newCap, VM_FLAGS_ANYWHERE) != KERN_SUCCESS) {
         return 0;
     }
     if (origLive > 0) {
         std::vector<uint8_t> stash(origLive);
-        if (!readParent(parentTask, origAddr, stash.data(), origLive) ||
-            !writeParent(parentTask, parentNew, stash.data(), origLive)) {
+        if (!readTranslate(parentTask, origAddr, stash.data(), origLive) ||
+            !writeTranslate(parentTask, parentNew, stash.data(), origLive)) {
             mach_vm_deallocate(parentTask, parentNew, newCap);
             return 0;
         }
     }
     if (tailSize > 0) {
-        if (!writeParent(parentTask, parentNew + origLive, tail, tailSize)) {
+        if (!writeTranslate(parentTask, parentNew + origLive, tail, tailSize)) {
             mach_vm_deallocate(parentTask, parentNew, newCap);
             return 0;
         }
@@ -1868,7 +1939,7 @@ TranslateOutcome processTranslateRequest(mach_port_t parentTask, const Translate
     TranslationResult tr{};
     // Read only the stock-sized TR from the tracee; x87_cache lives in our own
     // per-thread map (keyed by TR address), not in the tracee's heap.
-    if (!readParent(parentTask, req.tr_addr, &tr, kStockTRSize)) {
+    if (!readTranslate(parentTask, req.tr_addr, &tr, kStockTRSize)) {
         return out;
     }
     {
@@ -1911,19 +1982,75 @@ TranslateOutcome processTranslateRequest(mach_port_t parentTask, const Translate
                         ._size = lists[i]->_size};
     }
 
-    // Read IR array + ThreadContextOffsets.
-    std::vector<IRInstr> localIR(req.num_instrs);
-    if (!readParent(parentTask, req.instr_array, localIR.data(),
-                    req.num_instrs * sizeof(IRInstr))) {
-        return out;
+    // IR array: serve from the per-block cache when possible (see the
+    // g_irCache comment for the reuse conditions and the ABA argument);
+    // otherwise read it in full from the tracee.
+    IRCacheEntry& irc = g_irCache[req.tr_addr];
+    {
+        const bool noIrCache =
+            g_rosetta_config != nullptr && g_rosetta_config->loader_no_ir_cache != 0U;
+        bool reuse = !noIrCache && irc.block == req.block && irc.instr_array == req.instr_array &&
+                     irc.num_instrs == req.num_instrs && req.insn_idx > irc.last_idx;
+        if (reuse) {
+            IRInstr probe;
+            if (!readTranslate(parentTask, req.instr_array + req.insn_idx * sizeof(IRInstr), &probe,
+                         sizeof(probe))) {
+                return out;
+            }
+            reuse = std::memcmp(&probe, &irc.ir[req.insn_idx], sizeof(IRInstr)) == 0;
+        }
+        if (reuse) {
+            g_statIrHits.fetch_add(1, std::memory_order_relaxed);
+        } else {
+            irc.ir.resize(req.num_instrs);
+            if (!readTranslate(parentTask, req.instr_array, irc.ir.data(),
+                         req.num_instrs * sizeof(IRInstr))) {
+                // Don't leave a half-valid entry behind: the vector was
+                // already resized, so stale keys could pair with the wrong
+                // length and index out of bounds on a later request.
+                irc = IRCacheEntry{};
+                return out;
+            }
+            irc.block = req.block;
+            irc.instr_array = req.instr_array;
+            irc.num_instrs = req.num_instrs;
+            g_statIrMisses.fetch_add(1, std::memory_order_relaxed);
+        }
+        irc.last_idx = req.insn_idx;
     }
+    IRInstr* const localIR = irc.ir.data();
 
     if (origTCO == nullptr) {
         return out;
     }
     ThreadContextOffsets localTCO{};
-    if (!readParent(parentTask, reinterpret_cast<uint64_t>(origTCO), &localTCO, sizeof(localTCO))) {
-        return out;
+    {
+        const bool noTcoCache =
+            g_rosetta_config != nullptr && g_rosetta_config->loader_no_tco_cache != 0U;
+        const uint64_t tcoAddr = reinterpret_cast<uint64_t>(origTCO);
+        auto it = noTcoCache ? g_tcoCache.end() : g_tcoCache.find(tcoAddr);
+        if (it != g_tcoCache.end()) {
+            localTCO = it->second;
+            g_statTcoHits.fetch_add(1, std::memory_order_relaxed);
+        } else {
+            if (!readTranslate(parentTask, tcoAddr, &localTCO, sizeof(localTCO))) {
+                return out;
+            }
+            if (!noTcoCache) {
+                // Canary for the constants assumption: all TCOs in a process
+                // must describe the same layout.
+                if (!g_tcoCache.empty() &&
+                    std::memcmp(&g_tcoCache.begin()->second, &localTCO, sizeof(localTCO)) != 0) {
+                    fprintf(stdout,
+                            "[rosettax87] WARNING: ThreadContextOffsets at 0x%llx differs from "
+                            "cached layout; TCO cache assumption broken, rerun with "
+                            "X87_NO_TCO_CACHE=1\n",
+                            static_cast<unsigned long long>(tcoAddr));
+                    fflush(stdout);
+                }
+                g_tcoCache.emplace(tcoAddr, localTCO);
+            }
+        }
     }
 
     // x87_cache (OPT-1) was loaded from g_x87Cache above, not from the tracee.
@@ -1963,10 +2090,10 @@ TranslateOutcome processTranslateRequest(mach_port_t parentTask, const Translate
     }
 
     dumpBlockIfNew(parentTask, reinterpret_cast<uint64_t>(tr.ir_module_data), req.block,
-                   localIR.data(), req.num_instrs);
+                   localIR, req.num_instrs);
 
     auto result = Translator::translate_instruction(
-        &tr, reinterpret_cast<IRBlock*>(req.block), localIR.data(),
+        &tr, reinterpret_cast<IRBlock*>(req.block), localIR,
         static_cast<int64_t>(req.num_instrs), static_cast<int64_t>(req.insn_idx));
 
     // Capture growth state. If insn_buf grew, Translator's grow() abandoned
@@ -2055,8 +2182,8 @@ TranslateOutcome processTranslateRequest(mach_port_t parentTask, const Translate
         uint64_t finalInsnCap = origInsnCap;
         if (!insnGrew && finalInsnEnd <= origInsnCap) {
             if (insnEmitted > 0) {
-                if (!writeParent(parentTask, reinterpret_cast<uint64_t>(origInsnData) + origInsnEnd,
-                                 localInsnData + origInsnEnd, insnEmitted)) {
+                if (!writeTranslate(parentTask, reinterpret_cast<uint64_t>(origInsnData) + origInsnEnd,
+                              localInsnData + origInsnEnd, insnEmitted)) {
                     return out;
                 }
             }
@@ -2088,8 +2215,8 @@ TranslateOutcome processTranslateRequest(mach_port_t parentTask, const Translate
 
             if (newLive <= parentCap) {
                 if (added > 0) {
-                    if (!writeParent(parentTask, reinterpret_cast<uint64_t>(orig.end),
-                                     localPushed[i], added)) {
+                    if (!writeTranslate(parentTask, reinterpret_cast<uint64_t>(orig.end), localPushed[i],
+                                  added)) {
                         return out;
                     }
                 }
@@ -2124,7 +2251,7 @@ TranslateOutcome processTranslateRequest(mach_port_t parentTask, const Translate
     // any pivoted buffer pointers from the Some path above). x87_cache is NOT
     // written to the tracee — it lives in g_x87Cache — so the tracee's TR needs
     // no enlargement and the M2 install needs no TR-size patch.
-    if (!writeParent(parentTask, req.tr_addr, &tr, kStockTRSize)) {
+    if (!writeTranslate(parentTask, req.tr_addr, &tr, kStockTRSize)) {
         return out;
     }
 
@@ -2169,26 +2296,63 @@ TranslateOutcome processTranslateRequest(mach_port_t parentTask, const Translate
     return out;
 }
 
+// True when `kr` is a receive-side mach_msg error (0x10004xxx, bit 14 set;
+// send-side errors are 0x10000xxx).  A combined SEND|RCV call can fail on
+// either half: a send-half failure means the reply was NOT queued (we still
+// own the SEND_ONCE right) and the receive half never ran; a receive-half
+// failure means the reply went out fine.
+constexpr bool machMsgRcvError(kern_return_t kr) {
+    return (kr & 0x00004000) != 0;
+}
+
 void runReceiveLoop(mach_port_t servicePort, mach_port_t parentTaskPort) {
     struct alignas(8) {
         uint8_t bytes[kRecvBufferSize];
     } buf;
 
+    struct ReplyMsg {
+        mach_msg_header_t hdr;
+        uint64_t result;
+        uint64_t some_flag;  // 1 = Some(result), 0 = None (fall through)
+    };
+
     uint64_t send_failures = 0;
+    bool replyPending = false;  // buf.bytes holds a ReplyMsg not yet sent
     for (;;) {
         auto* hdr = reinterpret_cast<mach_msg_header_t*>(buf.bytes);
-        hdr->msgh_local_port = servicePort;
-        hdr->msgh_size = sizeof(buf);
-
-        kern_return_t kr = mach_msg(hdr, MACH_RCV_MSG, 0, sizeof(buf), servicePort,
-                                    MACH_MSG_TIMEOUT_NONE, MACH_PORT_NULL);
+        kern_return_t kr;
+        if (replyPending) {
+            // MIG-server shape: send the pending reply and block for the
+            // next request in ONE trap (the received message reuses the
+            // same buffer).  Halves the per-request mach_msg count vs the
+            // old separate SEND + RCV calls.
+            replyPending = false;
+            kr = mach_msg(hdr, MACH_SEND_MSG | MACH_RCV_MSG, sizeof(ReplyMsg), sizeof(buf),
+                          servicePort, MACH_MSG_TIMEOUT_NONE, MACH_PORT_NULL);
+            if (kr != KERN_SUCCESS && !machMsgRcvError(kr)) {
+                if (++send_failures <= 5) {
+                    fprintf(stdout, "sidecar: reply send failed 0x%x %s\n", kr,
+                            mach_error_string(kr));
+                }
+                // mach_msg consumes the SEND_ONCE on success; on send
+                // failure we must drop it ourselves, then retry as a
+                // plain receive.
+                mach_port_deallocate(mach_task_self(), hdr->msgh_remote_port);
+                continue;
+            }
+        } else {
+            hdr->msgh_local_port = servicePort;
+            hdr->msgh_size = sizeof(buf);
+            kr = mach_msg(hdr, MACH_RCV_MSG, 0, sizeof(buf), servicePort, MACH_MSG_TIMEOUT_NONE,
+                          MACH_PORT_NULL);
+        }
         if (kr != KERN_SUCCESS) {
             fprintf(stdout, "sidecar: mach_msg(RCV) returned 0x%x (%s)\n", kr,
                     mach_error_string(kr));
             return;
         }
 
-        const uint64_t hits = g_hits.fetch_add(1, std::memory_order_relaxed) + 1;
+        g_hits.fetch_add(1, std::memory_order_relaxed);
 
         // M3 payload: header (24 B) + 5 × 8-byte args (40 B) = 64 B.
         // Args are TR*, IRBlock*, IRInstr*, num_instrs, insn_idx — the
@@ -2210,32 +2374,20 @@ void runReceiveLoop(mach_port_t servicePort, mach_port_t parentTaskPort) {
 
             TranslateOutcome outcome = processTranslateRequest(parentTaskPort, req);
 
-            struct ReplyMsg {
-                mach_msg_header_t hdr;
-                uint64_t result;
-                uint64_t some_flag;  // 1 = Some(result), 0 = None (fall through)
-            } reply{};
-            reply.hdr.msgh_bits = MACH_MSGH_BITS(MACH_MSG_TYPE_MOVE_SEND_ONCE, 0);
-            reply.hdr.msgh_size = sizeof(reply);
-            reply.hdr.msgh_remote_port = replyPort;
-            reply.hdr.msgh_local_port = MACH_PORT_NULL;
-            reply.hdr.msgh_id = reqId;  // echo for transaction match
-            reply.result = outcome.reply_some ? static_cast<uint64_t>(outcome.value) : 0;
-            reply.some_flag = outcome.reply_some ? 1U : 0U;
-
-            kern_return_t kr_send = mach_msg(&reply.hdr, MACH_SEND_MSG, sizeof(reply), 0,
-                                             MACH_PORT_NULL, MACH_MSG_TIMEOUT_NONE, MACH_PORT_NULL);
-            if (kr_send != KERN_SUCCESS) {
-                if (++send_failures <= 5) {
-                    fprintf(stdout, "sidecar: #%llu reply send failed 0x%x %s\n",
-                            static_cast<unsigned long long>(hits), kr_send,
-                            mach_error_string(kr_send));
-                }
-                // mach_msg consumes the SEND_ONCE on success; on failure
-                // we must drop it ourselves.
-                mach_port_deallocate(mach_task_self(), replyPort);
-            }
-            // mach_msg(SEND) on success consumed replyPort. Don't drop it.
+            // Build the reply in place over the request bytes; it goes out
+            // fused with the next receive at the top of the loop.  Every
+            // header field is set explicitly since the buffer holds the
+            // stale request header.
+            auto* reply = reinterpret_cast<ReplyMsg*>(buf.bytes);
+            reply->hdr.msgh_bits = MACH_MSGH_BITS(MACH_MSG_TYPE_MOVE_SEND_ONCE, 0);
+            reply->hdr.msgh_size = sizeof(ReplyMsg);
+            reply->hdr.msgh_remote_port = replyPort;
+            reply->hdr.msgh_local_port = MACH_PORT_NULL;
+            reply->hdr.msgh_voucher_port = MACH_PORT_NULL;
+            reply->hdr.msgh_id = reqId;  // echo for transaction match
+            reply->result = outcome.reply_some ? static_cast<uint64_t>(outcome.value) : 0;
+            reply->some_flag = outcome.reply_some ? 1U : 0U;
+            replyPending = true;
         } else if (replyPort != MACH_PORT_NULL &&
                    (hdr->msgh_bits & MACH_MSGH_BITS_REMOTE_MASK) == MACH_MSG_TYPE_MOVE_SEND_ONCE) {
             // Other / malformed message — discard the SEND_ONCE.
@@ -2261,6 +2413,7 @@ constexpr unsigned kReporterPeriodSec = 2;
 void* reporterEntry(void* /*arg*/) {
     pthread_setname_np("rosettax87-reporter");
     uint64_t prev_total = 0;
+    uint64_t prev_vm = 0;
     bool printed_idle = false;
     for (;;) {
         const struct timespec ts = {.tv_sec = kReporterPeriodSec, .tv_nsec = 0};
@@ -2268,6 +2421,9 @@ void* reporterEntry(void* /*arg*/) {
         const uint64_t cur = g_hits.load(std::memory_order_relaxed);
         const uint64_t delta = cur - prev_total;
         prev_total = cur;
+        const uint64_t vm = g_statVmSyscalls.load(std::memory_order_relaxed);
+        const uint64_t vm_delta = vm - prev_vm;
+        prev_vm = vm;
         if (delta == 0) {
             if (!printed_idle && cur > 0) {
                 fprintf(stdout, "[rosettax87] sidecar: idle (total %llu)\n",
@@ -2278,9 +2434,18 @@ void* reporterEntry(void* /*arg*/) {
             continue;
         }
         printed_idle = false;
-        fprintf(stdout, "[rosettax87] sidecar: %llu req/s (total %llu)\n",
+        // vm/req counts mach_vm_* traps on the translate path this period
+        // (mach_msg excluded: 1/request by construction).  Cache columns are
+        // cumulative hits/misses so rates are readable at a glance.
+        fprintf(stdout,
+                "[rosettax87] sidecar: %llu req/s (total %llu) vm/req=%.2f "
+                "ir=%llu/%llu tco=%llu\n",
                 static_cast<unsigned long long>(delta / kReporterPeriodSec),
-                static_cast<unsigned long long>(cur));
+                static_cast<unsigned long long>(cur),
+                static_cast<double>(vm_delta) / static_cast<double>(delta),
+                static_cast<unsigned long long>(g_statIrHits.load(std::memory_order_relaxed)),
+                static_cast<unsigned long long>(g_statIrMisses.load(std::memory_order_relaxed)),
+                static_cast<unsigned long long>(g_statTcoHits.load(std::memory_order_relaxed)));
         fflush(stdout);
     }
 }


### PR DESCRIPTION
Every translate_insn request the tracee routes to the sidecar used to cost 7 traps in steady state: a mach_msg receive, a mach_vm read each for the TranslationResult (616 B), the whole IR array (80 B per instruction), and the ThreadContextOffsets struct, one to seven mach_vm writes, and a mach_msg reply. The IR array was re-read in full for every instruction of a block, so a 100-instruction block paid about 8 KB of cross-task reads per x87 run in it. This lands the syscall reductions that survive scrutiny, and documents the one that does not.

## What changed

The reply send and the next request receive are now one `mach_msg(MACH_SEND_MSG|MACH_RCV_MSG)` trap, the classic MIG-server shape. The reply is built in place over the request buffer and goes out fused with the next receive; a send-half failure falls back to a plain receive so the loop keeps serving.

The block's IR array is cached per TR address. The translator never mutates the tracee's IR (fusion works on a local copy), so it is read-only cross-task and constant while stock walks the block. Reuse requires the (block, instr_array, num_instrs) triple to match, the walk to stay monotonic (a new pass restarts at a lower-or-equal index), and an 80-byte probe read of the current IRInstr to compare equal against the cached copy. The full-array read now happens once per block pass instead of once per request, and the per-request vector malloc is gone too. The residual ABA needs recycled pointers with a byte-identical current IRInstr but different lookahead entries, which means guest self-modifying code re-decoded at the same pc; `X87_NO_IR_CACHE=1` is the hatch.

ThreadContextOffsets is cached by pointer. Stock re-materialises the struct on the calling thread's stack, so the same pointer recurs per thread, and the contents are process-lifetime layout constants. Every miss cross-checks the new read against the first cached copy and logs loudly if that assumption ever breaks; `X87_NO_TCO_CACHE=1` is the hatch.

The `X87_LOG_THROUGHPUT` reporter line now carries `vm/req` (mach_vm traps per request on the translate path) and the cache hit/miss counters, so the effect is visible on a live run and future regressions have a number to show up in.

## What was tried and reverted

`mach_vm_remap(copy=FALSE)` of the tracee's TR / insn-buf / IR pages into the sidecar, to turn the remaining reads and writes into memcpys, does not work and the tree now documents why. The tracee is an x86_64-translated task with 4 KB VM pages; remapping its private anonymous memory into the sidecar's 16 KB arm64 map silently degrades to copy semantics, and the two views diverge in both directions (verified with a shadow-verify mode that ran every window access and the syscall side by side: reads returned remap-time bytes, writes never reached the tracee). Sharing works only in the opposite direction, for pages the sidecar allocates and remaps into the tracee, which is how the profile counter array is wired. A NOTE above `g_irCache` and a README paragraph record the dead end.

## Numbers

On a 30-block x87 probe: 464 requests, `vm/req` 4.01 with the caches on vs 5.01 with them off, IR cache 313 hits / 150 full reads (the hit rate scales with runs per block), TCO cache 462 of 464. With the fused mach_msg that is 5 traps per request instead of 7, and the dominant read volume (the IR array) is gone on every request after the first per block. Cold-translation latency only; steady state was already off the sidecar path.

## Verification

`scripts/run_tests.sh` 962/962 on this branch. The caches were also bisected individually against a build that additionally carried the (now removed) remap windows: each cache alone is green, the windows alone reproduced the corruption, which is what prompted the shadow-verify diagnosis above.
