### PR TITLE
Make FMA contraction opt-in: real x87 rounds the product before the add

### DIFF
--- a/rosetta_core/include/rosetta_core/Config.h
+++ b/rosetta_core/include/rosetta_core/Config.h
@@ -45,6 +45,11 @@ struct RosettaConfig {
     uint8_t disable_x87_ir;         // X87_DISABLE_X87_IR        disable IR optimisation pipeline
     uint8_t disable_x87_single_fast;  // X87_DISABLE_SINGLE_FAST fall back to the generic
                                       // per-op emitters for isolated (run==1) fld/fst/fstp
+    uint8_t enable_fma_contract;      // X87_ENABLE_FMA_CONTRACT   contract FMul+FAdd/FSub into
+                                      //   one FMA node.  Default OFF: real x87 rounds the product
+                                      //   before the add, FMA does not, and the 1-ulp difference
+                                      //   amplifies through catastrophic cancellation (seen as
+                                      //   corrupted audio-resample steps in Call of Duty 2).
     uint8_t enable_fma_reduce;        // X87_ENABLE_FMA_REDUCE     NEON FMA-reduction pass
                                       //                           (default ON).  Pays off on
                                       //                           +4-contiguous dot products

--- a/rosetta_core/src/ConfigEnv.cpp
+++ b/rosetta_core/src/ConfigEnv.cpp
@@ -136,6 +136,7 @@ RosettaConfig load_config_from_env() {
     cfg.disable_deferred_fxch = env_truthy("X87_DISABLE_DEFERRED_FXCH") ? 1 : 0;
     cfg.disable_x87_ir = env_truthy("X87_DISABLE_X87_IR") ? 1 : 0;
     cfg.disable_x87_single_fast = env_truthy("X87_DISABLE_SINGLE_FAST") ? 1 : 0;
+    cfg.enable_fma_contract = env_truthy("X87_ENABLE_FMA_CONTRACT") ? 1 : 0;
     cfg.enable_fma_reduce = env_default_on("X87_ENABLE_FMA_REDUCE");
     cfg.enable_ir_split = env_default_on("X87_ENABLE_IR_SPLIT");
     cfg.enable_ir_remat = env_default_on("X87_ENABLE_IR_REMAT");
@@ -328,6 +329,9 @@ void print_env_help(std::FILE* out) {
         "  X87_DISABLE_SINGLE_FAST=1     disable the fused single-op fast path for\n"
         "                                isolated (run==1) fld/fst/fstp — fall back\n"
         "                                to the generic per-op emitters\n"
+        "  X87_ENABLE_FMA_CONTRACT=1     contract FMul+FAdd/FSub into a single FMA\n"
+        "                                (off by default: skips the intermediate\n"
+        "                                rounding real x87 performs)\n"
         "  X87_ENABLE_FMA_REDUCE=0       disable NEON FMA-reduction lowering for serial\n"
         "                                FMADD chains.  Default ON.  Pays off only on\n"
         "                                workloads with +4-contiguous data/weight\n"

--- a/rosetta_core/src/X87IROptimize.cpp
+++ b/rosetta_core/src/X87IROptimize.cpp
@@ -697,7 +697,12 @@ static void pass_fma_reduce(Context& ctx) {
 
 void optimize(Context& ctx) {
     pass_dse(ctx);
-    pass_fma(ctx);
+    // FMA contraction changes numerics (no intermediate rounding of the
+    // product), so it must be opt-in.  pass_fma_reduce only matches FMAdd
+    // nodes pass_fma creates, so gating the former also starves the latter.
+    if (g_rosetta_config != nullptr && g_rosetta_config->enable_fma_contract != 0) {
+        pass_fma(ctx);
+    }
     pass_fma_reduce(ctx);
     pass_fcom_fstsw_fusion(ctx);
 }


### PR DESCRIPTION
pass_fma unconditionally contracted FMul + FAdd/FSub into a single ARM FMA node. Real x87 rounds the intermediate product to operand precision before the addition; FMA keeps the infinitely-precise product. The 1-ulp difference amplifies through catastrophic cancellation.

Found on Call of Duty 2 (32-bit, wow64, CrossOver): Miles Sound System computes 65536·2^x resample steps through an x87 chain, and the contracted result diverged from stock Rosetta. A 6-op differential repro (same ops run under stock vs sidecar) DIVERGEs before this change and MATCHes after; happy to attach it if useful.

This gates the pass behind `X87_ENABLE_FMA_CONTRACT` (default off). `pass_fma_reduce` only matches FMAdd nodes that `pass_fma` creates, so gating the former also starves the latter — no separate gate needed.

All 968 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)