### PR TITLE
Make hash_ir_stream stable across launches, re-decodes and host versions

### DIFF
--- a/rosetta_core/src/ProfileRuntime.cpp
+++ b/rosetta_core/src/ProfileRuntime.cpp
@@ -10,6 +10,7 @@
 #include <unordered_map>
 
 #include "rosetta_core/IRInstr.h"
+#include "rosetta_core/OpcodeCompatibility.h"
 #include "rosetta_core/ProfileFormat.h"
 
 namespace profile {
@@ -114,15 +115,85 @@ uint32_t register_block(const IRBlock* block, uint64_t ir_hash) {
 }
 
 uint64_t hash_ir_stream(const IRInstr* instrs, size_t num_instrs) {
-    // 64-bit FNV-1a, with each IRInstr's `pc` field zeroed before hashing
-    // so the same logical IR produces the same hash across runs (codegen
-    // may place the block at different PCs each run).
+    // 64-bit FNV-1a over a CANONICALIZED copy of each IRInstr, so the same
+    // logical IR hashes identically across launches, re-decodes AND host
+    // Rosetta versions:
+    //   - `opcode_` mapped to the internal id (opcode_host_to_internal):
+    //     26.4 hosts and 26.5+ hosts encode the same instruction with
+    //     different raw ids; hashing the internal id keeps X87_*_HASH_LIST
+    //     values portable across macOS versions.  On modern hosts the map
+    //     is identity, so existing modern-host hashes are unchanged.
+    //   - `pc` zeroed: codegen may place the block at a different PC each run.
+    //   - `flag_liveness` zeroed: recomputed from the block's successors on
+    //     every decode; changes with no code change.
+    //   - `_pad08` zeroed.
+    //   - operand slots >= num_operands zeroed entirely: the decoder leaves
+    //     stack garbage (per-run pointer values) in them.
+    //   - used operands rebuilt field-by-field per kind: the union's dead
+    //     value fields (IROperandRegister::_unused et al.) and pad bytes
+    //     carry the same per-run garbage.
+    // Zeroing only `pc` (the old behaviour) left that garbage in the hash
+    // input, so the hash was NOT stable across launches — which silently
+    // broke every cross-run use of X87_*_HASH_LIST and profile_analyze
+    // --dump-block-by-hash.  Verified empirically on the same binary run
+    // twice: every block hashed differently until dead bytes were masked.
     constexpr uint64_t kFnvOffset = 14695981039346656037ULL;
     constexpr uint64_t kFnvPrime = 1099511628211ULL;
     uint64_t h = kFnvOffset;
     for (size_t i = 0; i < num_instrs; ++i) {
         IRInstr tmp = instrs[i];
+        tmp.opcode_ = opcode_host_to_internal(tmp.opcode_);
         tmp.pc = 0;
+        tmp._pad08 = 0;
+        tmp.flag_liveness = 0;
+        const int nops = tmp.num_operands > 4 ? 4 : tmp.num_operands;
+        for (int o = 0; o < 4; ++o) {
+            const IROperand src = tmp.operands[o];
+            IROperand canon{};
+            std::memset(&canon, 0, sizeof(canon));
+            if (o < nops) {
+                switch (src.kind) {
+                    case IROperandKind::Register:
+                        canon.reg.kind = src.reg.kind;
+                        canon.reg.size = src.reg.size;
+                        canon.reg.reg = src.reg.reg;
+                        canon.reg.seg_override = src.reg.seg_override;
+                        break;
+                    case IROperandKind::MemRef:
+                        canon.mem = src.mem;  // every byte is semantic
+                        break;
+                    case IROperandKind::AbsMem:
+                        canon.abs_mem.kind = src.abs_mem.kind;
+                        canon.abs_mem.size = src.abs_mem.size;
+                        canon.abs_mem.addr_size = src.abs_mem.addr_size;
+                        canon.abs_mem.value = src.abs_mem.value;
+                        break;
+                    case IROperandKind::Immediate:
+                        canon.imm.kind = src.imm.kind;
+                        canon.imm.size = src.imm.size;
+                        canon.imm.addr_size = src.imm.addr_size;
+                        canon.imm.mem_flags = src.imm.mem_flags;
+                        canon.imm.value = src.imm.value;
+                        break;
+                    case IROperandKind::BranchOffset:
+                        canon.branch.kind = src.branch.kind;
+                        canon.branch.value = src.branch.value;
+                        break;
+                    case IROperandKind::ConditionCode:
+                        canon.cc.kind = src.cc.kind;
+                        canon.cc.cc = src.cc.cc;
+                        break;
+                    case IROperandKind::SegmentRegister:
+                        canon.seg.kind = src.seg.kind;
+                        canon.seg.seg_idx = src.seg.seg_idx;
+                        break;
+                    default:
+                        canon = src;  // unknown kind: keep raw, don't guess
+                        break;
+                }
+            }
+            tmp.operands[o] = canon;
+        }
         const auto* bytes = reinterpret_cast<const uint8_t*>(&tmp);
         for (size_t b = 0; b < sizeof(IRInstr); ++b) {
             h ^= bytes[b];


### PR DESCRIPTION
The IR-content hash is documented (and used) as a launch-stable block identity for `X87_BRIDGE_HASH_LIST` / `X87_ROLLBACK_HASH_LIST` and `profile_analyze --dump-block-by-hash`. Zeroing only `pc` did not achieve that — measured on the same binary run twice, **every block hashed differently**, because the FNV input still contained per-run garbage:

- unused operand slots (`operands[i >= num_operands]`) hold decoder stack leftovers — frequently live pointer values that change with ASLR;
- dead union fields of used operands (`IROperandRegister::_unused` et al.) and pad bytes carry the same garbage;
- `flag_liveness` is recomputed from the block's successors on every decode and can change with no code change;
- raw `opcode_` ids differ between 26.4 and 26.5+ hosts, so hashes were not portable across macOS versions.

This canonicalizes before hashing: map `opcode_` to the internal id (identity on modern hosts, so existing modern-host hash values are unchanged), zero `pc`/`_pad08`/`flag_liveness`, zero unused operand slots, and rebuild used operands field-by-field per operand kind. After this, the same logical block hashes identically across launches even when its guest copy is mapped at a different address (verified on a game workload: 4 copies of the same 10-op chain at 4 addresses → one hash), and hash-list values survive OS updates.

All 968 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)