### PR TITLE
Add block-precise stock forcing and translation diagnostics (X87_STOCK_HASH_LIST et al.)

### DIFF
--- a/rosetta_core/include/rosetta_core/Config.h
+++ b/rosetta_core/include/rosetta_core/Config.h
@@ -109,6 +109,30 @@ struct RosettaConfig {
     // workload.
     std::vector<uint64_t> x87_bridge_hash_list;     // sorted, binary-searched
     std::vector<uint64_t> x87_no_bridge_hash_list;  // sorted, binary-searched
+    // X87_STOCK_HASH_LIST — hand ENTIRE blocks to stock Rosetta by
+    // IR-content hash (same key as the lists above).  Unlike the bridge /
+    // rollback lists this skips the sidecar translator completely for the
+    // listed blocks: every translate request in such a block gets a None
+    // reply, exactly what X87_ALWAYS_NONE does process-wide, but
+    // block-precise.  This is the only per-block exclusion that works under
+    // wow64, where the sidecar sees host-side PCs only and guest-address
+    // range filtering cannot target a guest module.
+    std::vector<uint64_t> x87_stock_hash_list;      // sorted, binary-searched
+
+    // X87_LOG_HASH_LIST — diagnostic: append a timestamped line (uptime
+    // seconds, same clock as WINEDEBUG +timestamp) to the X87_DIAG_DIR file
+    // for every translate request whose block IR-content hash is listed.
+    // Answers "was this block (re)translated near the corruption moment, or
+    // was its code static for minutes" — the translation-side vs
+    // execution-side discriminator.
+    std::vector<uint64_t> x87_log_hash_list;        // sorted, binary-searched
+
+    // X87_STOCK_OPS — hand to stock every block CONTAINING any of the listed
+    // opcodes (comma-separated mnemonic names, e.g. "f2xm1,fscale").  Coarser
+    // than the hash list but robust against hash instability: use it to
+    // localize a miscompile to "blocks with opcode X" in one run, then narrow
+    // by hash.  Resolved to opcode ids at env-parse time.
+    std::vector<uint16_t> x87_stock_ops;            // sorted, binary-searched
     uint8_t force_x87_ir_gate;       // measurement-only flag for tools/profile_analyze: bypass
                                      // the IR-eligibility gate's pre-build refusal conditions
                                      // (run_remaining<3, top_dirty, deferred_pop_count,

--- a/rosetta_core/include/rosetta_core/X87Cache.h
+++ b/rosetta_core/include/rosetta_core/X87Cache.h
@@ -13,6 +13,23 @@ struct IRInstr;
 // Caching these two values across instructions saves 3-4 emitted AArch64
 // instructions per x87 opcode after the first in a run.
 struct X87Cache {
+    int32_t last_insn_idx = -1;  // Last insn_idx asked for in this block: a
+                                 // stock pass restarting from a smaller or
+                                 // equal index invalidates the mid-run cache
+                                 // state — the code that loaded base/top has
+                                 // been thrown away with the aborted pass.
+    uint64_t last_buf_end = 0;   // insn_buf.end after the last call: on a
+                                 // mid-span re-ask this shows whether stock
+                                 // rolled back our emitted BYTES (end < frontier).
+    int32_t last_next_idx = -1;  // next_idx returned by the last call (the
+                                 // consumption frontier; -1 = None/unknown).
+                                 // A mid-run request with insn_idx != this
+                                 // frontier means stock rolled its pass back
+                                 // INTO an already-consumed span
+                                 // (fusion/peephole/IR run): continuing in
+                                 // register mode would emit the span's tail
+                                 // without its head (observed as faddp
+                                 // without fld1 -> Miles pitch 2^x-1).
     int8_t base_gpr = 0;        // GPR holding X87State base
     int8_t top_gpr = 0;         // GPR holding TOP
     int16_t run_remaining = 0;  // Countdown; 0 = inactive

--- a/rosetta_core/src/ConfigEnv.cpp
+++ b/rosetta_core/src/ConfigEnv.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "rosetta_core/Config.h"
+#include "rosetta_core/Opcode.h"
 
 namespace {
 
@@ -204,6 +205,47 @@ RosettaConfig load_config_from_env() {
                     cfg.x87_no_bridge_hash_list.size());
     }
 
+    if (const char* v = std::getenv("X87_STOCK_HASH_LIST"); v != nullptr && v[0] != '\0') {
+        parse_hash_list(v, cfg.x87_stock_hash_list);
+        std::printf("[rosettax87] X87_STOCK_HASH_LIST: %zu unique hashes\n",
+                    cfg.x87_stock_hash_list.size());
+    }
+    if (const char* v = std::getenv("X87_LOG_HASH_LIST"); v != nullptr && v[0] != '\0') {
+        parse_hash_list(v, cfg.x87_log_hash_list);
+        std::printf("[rosettax87] X87_LOG_HASH_LIST: %zu unique hashes\n",
+                    cfg.x87_log_hash_list.size());
+    }
+    if (const char* v = std::getenv("X87_STOCK_OPS"); v != nullptr && v[0] != '\0') {
+        char buf[4096];
+        std::strncpy(buf, v, sizeof(buf) - 1);
+        buf[sizeof(buf) - 1] = '\0';
+        char* save = nullptr;
+        for (char* tok = strtok_r(buf, ",", &save); tok != nullptr;
+             tok = strtok_r(nullptr, ",", &save)) {
+            bool found = false;
+            for (size_t op = 0; op < kOpcodeNames.size(); ++op) {
+                if (kOpcodeNames[op] != nullptr && std::strcmp(kOpcodeNames[op], tok) == 0) {
+                    cfg.x87_stock_ops.push_back(static_cast<uint16_t>(op));
+                    found = true;
+                    // No break: a mnemonic may map to several opcode ids
+                    // (Rosetta assigns per-encoding ids); list them all.
+                }
+            }
+            if (!found) {
+                std::printf("[rosettax87] X87_STOCK_OPS: unknown opcode '%s' (ignored)\n", tok);
+            }
+        }
+        std::ranges::sort(cfg.x87_stock_ops);
+        const auto dup = std::ranges::unique(cfg.x87_stock_ops);
+        cfg.x87_stock_ops.erase(dup.begin(), dup.end());
+        std::printf("[rosettax87] X87_STOCK_OPS: %zu opcode ids resolved:",
+                    cfg.x87_stock_ops.size());
+        for (const uint16_t op : cfg.x87_stock_ops) {
+            std::printf(" 0x%x", static_cast<unsigned>(op));
+        }
+        std::printf("\n");
+    }
+
     if (env_truthy("X87_DISABLE_ALL_FUSIONS")) {
         cfg.disabled_fusions_mask = ~0ULL;
     }
@@ -373,6 +415,15 @@ void print_env_help(std::FILE* out) {
         "                                or profile_analyze)\n"
         "  X87_NO_BRIDGE_HASH_LIST=H,... never bridge the listed blocks (wins over\n"
         "                                the include list)\n"
+        "  X87_STOCK_HASH_LIST=H,...     hand the listed blocks to stock Rosetta\n"
+        "                                ENTIRELY (every translate request in a block\n"
+        "                                whose IR-content hash is listed replies None,\n"
+        "                                as X87_ALWAYS_NONE does process-wide).  The\n"
+        "                                per-block exclusion that works under wow64,\n"
+        "                                where guest-PC filtering cannot see a module\n"
+        "  X87_STOCK_OPS=name,...        hand to stock every block CONTAINING any of\n"
+        "                                the listed opcodes (mnemonics, e.g. f2xm1);\n"
+        "                                coarse one-run localizer, narrow by hash next\n"
         "  X87_SAMPLE=<file>             sampling profiler: write a guest-pc sample\n"
         "                                profile here (rosettax87 only).  Setting it\n"
         "                                enables sampling, as X87_PROFILE does for the\n"

--- a/rosetta_core/src/Translator.cpp
+++ b/rosetta_core/src/Translator.cpp
@@ -2,7 +2,10 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <unistd.h>
+
 #include <cstdio>
+#include <cstdlib>
 #include <optional>
 
 #include "rosetta_core/AssemblerHelpers.hpp"
@@ -33,7 +36,24 @@ static bool is_x87_opcode(uint16_t op) {
            (op >= kOpcodeName_f2xm1 && op <= kOpcodeName_fyl2xp1);
 }
 
+// Real body; the public translate_instruction wraps it to record the
+// consumed frontier (last_next_idx) after every exit path in one place.
+static auto translate_instruction_impl(TranslationResult* translation_result, IRBlock* block,
+                                       IRInstr* instr_array, int64_t num_instrs, int64_t insn_idx)
+    -> std::optional<int64_t>;
+
 auto Translator::translate_instruction(TranslationResult* translation_result, IRBlock* block,
+                                       IRInstr* instr_array, int64_t num_instrs, int64_t insn_idx)
+    -> std::optional<int64_t> {
+    const auto ret =
+        translate_instruction_impl(translation_result, block, instr_array, num_instrs, insn_idx);
+    translation_result->x87_cache.last_next_idx =
+        ret.has_value() ? static_cast<int32_t>(*ret) : -1;
+    translation_result->x87_cache.last_buf_end = translation_result->insn_buf.end;
+    return ret;
+}
+
+static auto translate_instruction_impl(TranslationResult* translation_result, IRBlock* block,
                                        IRInstr* instr_array, int64_t num_instrs, int64_t insn_idx)
     -> std::optional<int64_t> {
     auto* const cur_instr = &instr_array[insn_idx];
@@ -46,7 +66,72 @@ auto Translator::translate_instruction(TranslationResult* translation_result, IR
     // Then, if no cache is active, scan ahead to find the length of the current
     // consecutive x87 run.  x87_cache_set_run only activates if run >= 2.
     {
-        if (block != cache.prev_block) {
+        // A restart of the same block's translation (the stock pass may
+        // start over from a smaller or equal index) must reset the cache
+        // exactly like a block change: base/top in registers refer to
+        // emitted code of the thrown-away pass.
+        //
+        // Mid-span re-ask: while a run is ACTIVE, the only legitimate
+        // continuation is insn_idx == last_next_idx (the previous call's
+        // consumption frontier).  Any other index means stock rolled its
+        // pass back INTO an already-consumed span (fusion/peephole/IR run)
+        // — the old last_insn_idx comparison does NOT catch this (it holds
+        // the call's entry index, not the frontier: the fld1;faddp pair
+        // enters at idx=6 and returns next=8, so a re-ask at idx=7 looked
+        // like a "continuation" and emitted faddp without fld1, losing the
+        // "+1" of the Miles pitch chain -> mixer #DE).  React like a
+        // restart: full cache reset, memory-based re-emission.
+        const bool midspan_reask = block == cache.prev_block && cache.active() &&
+                                   cache.last_next_idx >= 0 &&
+                                   insn_idx != static_cast<int64_t>(cache.last_next_idx);
+        const bool restart_same_block =
+            (block == cache.prev_block && insn_idx <= cache.last_insn_idx) || midspan_reask;
+        if (midspan_reask) {
+            static int midspan_count = 0;
+            ++midspan_count;
+            if (midspan_count <= 10 || midspan_count % 100 == 0) {
+                std::fprintf(stdout,
+                             "[x87midspan] #%d hash=0x%016llx ask=%lld frontier=%d last_in=%d "
+                             "run=%d st{td=%d tp=%d dp=%d pd=%d} buf_now=%llu buf_last=%llu\n",
+                             midspan_count, static_cast<unsigned long long>(cache.profile_hash),
+                             static_cast<long long>(insn_idx), cache.last_next_idx,
+                             cache.last_insn_idx, static_cast<int>(cache.run_remaining),
+                             static_cast<int>(cache.top_dirty),
+                             static_cast<int>(cache.tag_push_pending),
+                             static_cast<int>(cache.deferred_pop_count),
+                             static_cast<int>(cache.perm_dirty),
+                             static_cast<unsigned long long>(translation_result->insn_buf.end),
+                             static_cast<unsigned long long>(cache.last_buf_end));
+                std::fflush(stdout);
+                // A respawned CrossOver game process loses its stdout —
+                // mirror to a per-pid file when X87_DIAG_DIR is set.
+                static FILE* diag = []() -> FILE* {
+                    const char* dir = std::getenv("X87_DIAG_DIR");
+                    if (dir == nullptr || dir[0] == '\0') {
+                        return nullptr;
+                    }
+                    char path[1024];
+                    std::snprintf(path, sizeof(path), "%s/x87midspan.%d.log", dir, getpid());
+                    return std::fopen(path, "a");
+                }();
+                if (diag != nullptr) {
+                    std::fprintf(diag,
+                                 "[x87midspan] #%d hash=0x%016llx ask=%lld frontier=%d last_in=%d "
+                                 "run=%d st{td=%d tp=%d dp=%d pd=%d} buf_now=%llu buf_last=%llu\n",
+                                 midspan_count, static_cast<unsigned long long>(cache.profile_hash),
+                                 static_cast<long long>(insn_idx), cache.last_next_idx,
+                                 cache.last_insn_idx, static_cast<int>(cache.run_remaining),
+                                 static_cast<int>(cache.top_dirty),
+                                 static_cast<int>(cache.tag_push_pending),
+                                 static_cast<int>(cache.deferred_pop_count),
+                                 static_cast<int>(cache.perm_dirty),
+                                 static_cast<unsigned long long>(translation_result->insn_buf.end),
+                                 static_cast<unsigned long long>(cache.last_buf_end));
+                    std::fflush(diag);
+                }
+            }
+        }
+        if (block != cache.prev_block || restart_same_block) {
             cache.invalidate();
             cache.prev_block = block;
             // Stock carries its register-allocator state across the block
@@ -59,6 +144,7 @@ auto Translator::translate_instruction(TranslationResult* translation_result, IR
             // our emits would clobber stock-live values at runtime.
             cache.stock_free_gpr_mask = translation_result->free_gpr_mask;
             translation_result->free_gpr_mask &= kGprScratchMask;
+            cache.last_insn_idx = -1;
             cache.tally_ir = 0;
             cache.tally_peep = 0;
             cache.tally_single = 0;
@@ -130,6 +216,9 @@ auto Translator::translate_instruction(TranslationResult* translation_result, IR
             }
             translation_result->free_gpr_mask &= kGprScratchMask;
         }
+        // Translation progress inside the block: a following call with
+        // idx <= this means the stock pass restarted.
+        cache.last_insn_idx = static_cast<int32_t>(insn_idx);
         if (!cache.active()) {
             const bool cache_disabled = g_rosetta_config && g_rosetta_config->disable_x87_cache;
             if (!cache_disabled) {

--- a/rosetta_loader/src/sidecar.cpp
+++ b/rosetta_loader/src/sidecar.cpp
@@ -2176,6 +2176,28 @@ TranslateOutcome processTranslateRequest(mach_port_t parentTask, const Translate
         tr.x87_cache = g_x87Cache[req.tr_addr];  // default-constructs on first use
     }
 
+    // Any None reply produced WITHOUT running the translator (the early
+    // failure returns below) must not leave the persisted per-TR X87Cache
+    // trusting mid-run registers: stock translates the op itself and
+    // clobbers the GPRs the cache thinks are holding TOP/base, so the next
+    // sidecar-translated op would miscompile.  The translator's own None
+    // paths invalidate in its default case; this guard covers every bypass
+    // in one place.
+    struct CacheBypassGuard {
+        uint64_t tr_addr;
+        bool ran_translator = false;
+        ~CacheBypassGuard() {
+            if (!ran_translator) {
+                std::scoped_lock lk(g_x87CacheMu);
+                auto it = g_x87Cache.find(tr_addr);
+                if (it != g_x87Cache.end()) {
+                    it->second.invalidate();
+                    it->second.prev_block = nullptr;
+                }
+            }
+        }
+    } _bypass_guard{.tr_addr = req.tr_addr};
+
     TransactionalList<Fixup>* lists[kListCount] = {
         &tr.external_fixups, &tr.internal_fixups,  &tr._fixups,
         &tr.field_B0,        &tr.dyld_stub_fixups, &tr.field_1A8,
@@ -2221,12 +2243,26 @@ TranslateOutcome processTranslateRequest(mach_port_t parentTask, const Translate
         bool reuse = !noIrCache && irc.block == req.block && irc.instr_array == req.instr_array &&
                      irc.num_instrs == req.num_instrs && req.insn_idx > irc.last_idx;
         if (reuse) {
-            IRInstr probe;
-            if (!readTranslate(parentTask, req.instr_array + req.insn_idx * sizeof(IRInstr), &probe,
-                         sizeof(probe))) {
+            // Probe a WINDOW, not a single instruction: the translator reads
+            // the whole run's lookahead (fusions, the IR pipeline, bridging
+            // via flag_liveness), so a stale cached tail miscompiles the
+            // block permanently.  The tail can go stale without any
+            // self-modification: IRInstr::flag_liveness depends on the
+            // block's successors and changes on re-decode.  Observed on
+            // Call of Duty 2 as the loss of fld1/faddp in the Miles pow2
+            // pitch chain (resample step 65536*(2^x-1) instead of
+            // 65536*2^x -> #DE in the mixer's division).
+            constexpr uint64_t kProbeWindow = 32;
+            IRInstr probe[kProbeWindow];
+            uint64_t win = req.num_instrs - req.insn_idx;
+            if (win > kProbeWindow) {
+                win = kProbeWindow;
+            }
+            if (!readTranslate(parentTask, req.instr_array + req.insn_idx * sizeof(IRInstr), probe,
+                         win * sizeof(IRInstr))) {
                 return out;
             }
-            reuse = std::memcmp(&probe, &irc.ir[req.insn_idx], sizeof(IRInstr)) == 0;
+            reuse = std::memcmp(probe, &irc.ir[req.insn_idx], win * sizeof(IRInstr)) == 0;
         }
         if (reuse) {
             g_statIrHits.fetch_add(1, std::memory_order_relaxed);
@@ -2321,6 +2357,7 @@ TranslateOutcome processTranslateRequest(mach_port_t parentTask, const Translate
     dumpBlockIfNew(parentTask, reinterpret_cast<uint64_t>(tr.ir_module_data), req.block,
                    localIR, req.num_instrs);
 
+    _bypass_guard.ran_translator = true;
     auto result = Translator::translate_instruction(
         &tr, reinterpret_cast<IRBlock*>(req.block), localIR,
         static_cast<int64_t>(req.num_instrs), static_cast<int64_t>(req.insn_idx));

--- a/rosetta_loader/src/sidecar.cpp
+++ b/rosetta_loader/src/sidecar.cpp
@@ -238,6 +238,24 @@ struct IRCacheEntry {
 };
 std::unordered_map<uint64_t, IRCacheEntry> g_irCache;
 
+// X87_DIAG_DIR=<dir>: append diagnostic lines to <dir>/x87diag.<pid>.log.
+// Some hosts (e.g. CrossOver respawning the game process) lose the
+// process's stdout entirely; a per-pid file is the only reliable channel
+// out of that process's sidecar.  Opened lazily on first use; nullptr
+// (and silent no-op) when the env is unset.
+FILE* diagLog() {
+    static FILE* f = []() -> FILE* {
+        const char* dir = std::getenv("X87_DIAG_DIR");
+        if (dir == nullptr || dir[0] == '\0') {
+            return nullptr;
+        }
+        char path[1024];
+        std::snprintf(path, sizeof(path), "%s/x87diag.%d.log", dir, getpid());
+        return std::fopen(path, "a");
+    }();
+    return f;
+}
+
 // NOTE on the road not taken: mach_vm_remap(copy=FALSE) of TRACEE-owned pages
 // into the sidecar (to turn the TR / insn-buf / fixup reads and writes below
 // into memcpys) does NOT work.  The tracee is an x86_64-translated task with
@@ -2357,10 +2375,84 @@ TranslateOutcome processTranslateRequest(mach_port_t parentTask, const Translate
     dumpBlockIfNew(parentTask, reinterpret_cast<uint64_t>(tr.ir_module_data), req.block,
                    localIR, req.num_instrs);
 
-    _bypass_guard.ran_translator = true;
-    auto result = Translator::translate_instruction(
-        &tr, reinterpret_cast<IRBlock*>(req.block), localIR,
-        static_cast<int64_t>(req.num_instrs), static_cast<int64_t>(req.insn_idx));
+    // X87_STOCK_HASH_LIST / X87_STOCK_OPS: hand whole blocks to stock by
+    // IR-content hash (profile::hash_ir_stream) or by contained opcode.
+    // Under wow64 the sidecar sees host-side PCs only, so content-based
+    // selection is the one per-block exclusion that can target a guest
+    // module's code.  Requests only arrive on (re)translation, never per
+    // execution, so hashing the block per request costs nothing in steady
+    // state.  X87_LOG_HASH_LIST appends an uptime-stamped line per request
+    // for the listed blocks (same clock as WINEDEBUG +timestamp), so a
+    // crash moment in a wine log can be correlated with the block's last
+    // (re)translation.
+    bool stock_hash_hit = false;
+    const bool haveStockHashes =
+        g_rosetta_config != nullptr && !g_rosetta_config->x87_stock_hash_list.empty();
+    const bool haveStockOps =
+        g_rosetta_config != nullptr && !g_rosetta_config->x87_stock_ops.empty();
+    const bool haveLogHashes =
+        g_rosetta_config != nullptr && !g_rosetta_config->x87_log_hash_list.empty();
+    if (haveStockHashes || haveStockOps || haveLogHashes) {
+        uint64_t block_hash = 0;
+        if (haveStockHashes || haveLogHashes) {
+            block_hash = profile::hash_ir_stream(localIR, req.num_instrs);
+        }
+        if (haveLogHashes &&
+            std::ranges::binary_search(g_rosetta_config->x87_log_hash_list, block_hash)) {
+            static int log_hits = 0;
+            ++log_hits;
+            if (log_hits <= 1000 || log_hits % 100 == 0) {
+                const double up =
+                    static_cast<double>(clock_gettime_nsec_np(CLOCK_UPTIME_RAW)) / 1e9;
+                if (FILE* df = diagLog()) {
+                    fprintf(df, "[x87trace] up=%.3f hit#%d hash=0x%016llx idx=%llu/%llu tr=%llx\n",
+                            up, log_hits, static_cast<unsigned long long>(block_hash),
+                            static_cast<unsigned long long>(req.insn_idx),
+                            static_cast<unsigned long long>(req.num_instrs),
+                            static_cast<unsigned long long>(req.tr_addr));
+                    fflush(df);
+                }
+            }
+        }
+        if (haveStockHashes) {
+            stock_hash_hit =
+                std::ranges::binary_search(g_rosetta_config->x87_stock_hash_list, block_hash);
+        }
+        if (!stock_hash_hit && haveStockOps) {
+            for (uint64_t i = 0; i < req.num_instrs && !stock_hash_hit; ++i) {
+                stock_hash_hit = std::ranges::binary_search(g_rosetta_config->x87_stock_ops,
+                                                            localIR[i].opcode());
+            }
+        }
+        if (stock_hash_hit) {
+            static int stock_hits = 0;
+            ++stock_hits;
+            if (stock_hits <= 5 || stock_hits % 1000 == 0) {
+                fprintf(stdout, "[x87stock] hit #%d hash=0x%016llx idx=%llu/%llu\n", stock_hits,
+                        static_cast<unsigned long long>(block_hash),
+                        static_cast<unsigned long long>(req.insn_idx),
+                        static_cast<unsigned long long>(req.num_instrs));
+                fflush(stdout);
+                if (FILE* df = diagLog()) {
+                    fprintf(df, "[x87stock] hit #%d hash=0x%016llx idx=%llu/%llu\n", stock_hits,
+                            static_cast<unsigned long long>(block_hash),
+                            static_cast<unsigned long long>(req.insn_idx),
+                            static_cast<unsigned long long>(req.num_instrs));
+                    fflush(df);
+                }
+            }
+        }
+    }
+
+    std::optional<int64_t> result;
+    if (!stock_hash_hit) {
+        _bypass_guard.ran_translator = true;
+        result = Translator::translate_instruction(
+            &tr, reinterpret_cast<IRBlock*>(req.block), localIR,
+            static_cast<int64_t>(req.num_instrs), static_cast<int64_t>(req.insn_idx));
+    }
+    // else: ran_translator stays false — the bypass guard invalidates the
+    // persisted X87Cache, exactly what a translator-bypassing None needs.
 
     // Capture growth state. If insn_buf grew, Translator's grow() abandoned
     // localInsnVec for a calloc'd buffer (we own that and must free it).
@@ -2547,7 +2639,10 @@ TranslateOutcome processTranslateRequest(mach_port_t parentTask, const Translate
             kOpcodeName_fxrstor,  // SSE-era extended
         };
         const uint16_t op = localIR[req.insn_idx].opcode();
-        const bool deliberate = std::ranges::find(kKnownFallThrough, op) != kKnownFallThrough.end();
+        // stock_hash_hit: the None reply is a deliberate whole-block
+        // exclusion, not a missing handler.
+        const bool deliberate = stock_hash_hit ||
+                                std::ranges::find(kKnownFallThrough, op) != kKnownFallThrough.end();
         if (!deliberate) {
             const char* name = (op < kOpcodeNames.size()) ? kOpcodeNames[op] : "?";
             fprintf(stdout,


### PR DESCRIPTION
**Stacked on #21** (includes its two commits; the new code deliberately reuses its `CacheBypassGuard`). Review the top commit only, or merge #21 first.

New knobs, all content-addressed by the (now launch-stable, see #20) IR hash — which matters under wow64, where the sidecar only ever sees host-side PCs and guest-address filtering cannot target a guest module:

- `X87_STOCK_HASH_LIST=0xH,...` — hand listed blocks ENTIRELY to stock: every translate request in such a block replies None, i.e. what `X87_ALWAYS_NONE` does process-wide, but block-precise. Requests only arrive on (re)translation, so the cost is confined to the cold path. This is both a bisect tool for a suspected per-block miscompile in a live workload and a surgical workaround: forcing one 10-instruction Miles pitch block to stock fixes the Call of Duty 2 audio-mixer #DE crash with no measurable FPS cost (2.5 h of play validated; controls crash in 82–137 s).
- `X87_STOCK_OPS=f2xm1,...` — force every block CONTAINING a listed opcode (mnemonics resolved at env-parse time). Coarse one-run localizer; narrow by hash afterwards.
- `X87_LOG_HASH_LIST=0xH,...` — append an uptime-stamped line per translate request for the listed blocks (same clock `WINEDEBUG=+timestamp` prints), so a crash timestamp in a wine log can be correlated with the block's last (re)translation — a translation-side vs execution-side discriminator.
- `X87_DIAG_DIR=<dir>` — mirror diagnostics to `<dir>/x87diag.<pid>.log` (CrossOver respawns lose the game process's stdout entirely).

All 968 tests pass on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)