### PR TITLE
loader: find hooks by name anchors and validate the runtime at startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ jobs:
       - name: Build
         run: cmake --build build --parallel
 
+      - name: Probe the installed Rosetta
+        # Locates every anchor this build hooks in the runner's Rosetta and
+        # validates the assumptions behind them; exits non-zero if any is off.
+        run: build/bin/x87sidecar --probe
+
       - name: Run tests
         # PT_ATTACH on macOS needs either the debugger entitlement (granted
         # via an interactive system dialog on first launch — not available

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The build emits two signed artifacts from one link. Both are published as `.tar.
 | Artifact | Signing | Trade-off |
 |---|---|---|
 | `x87sidecar` | ad-hoc, **no entitlements** | Can be notarized. The default (`task_for_pid`) attach then only works as root (`sudo`); cooperative attach works without it. |
-| `x87sidecar_entitled` | same Mach-O + `cs.debugger` + `get-task-allow` | Default attach works against any target without `sudo`; the first attach just triggers a one-time macOS developer-tools authorization dialog. Not notarizable (`get-task-allow` is rejected). |
+| `x87sidecar_entitled` | same Mach-O + `cs.debugger` + `get-task-allow` | Default attach works against any target without `sudo`; macOS asks for developer-tools authorization (a password dialog) once per login session, before the target is launched. Not notarizable (`get-task-allow` is rejected). |
 
 The two are byte-identical except for the signature. Downloaded copies carry the quarantine attribute, so clear it with `xattr -d com.apple.quarantine <file>` before running. The test scripts point at `x87sidecar_entitled`; under CI's `sudo` either would work.
 
@@ -121,6 +121,8 @@ cmake --build build
 ```
 
 This produces both `build/bin/x87sidecar` (flat) and `build/bin/x87sidecar_entitled` (see [Binaries](#binaries)). Tests and benchmarks are built automatically.
+
+Nothing in the tree is tied to a particular macOS or Rosetta build number. At startup the loader locates what it patches in the installed Rosetta images by the anchors that survive a rebuild (the exported `translator_translate`, the name each function hands its own assert calls, the opcode mnemonic table) and checks the assumptions the emitted code relies on against the installed runtime: the opcode numbering behind the stub's x87 ranges, the size of a `TranslationResult`, the shape of `decode_opcode` around the fields the decode hook rewrites, and that the bytes each hook displaces are relocatable. A runtime that fails a check is refused before the target is launched rather than patched at guessed addresses. `x87sidecar --probe` runs exactly that analysis, prints what it found, and exits 0 only if this build supports the installed Rosetta with every feature, which is the first thing to run after a macOS update.
 
 ```bash
 bash scripts/run_tests.sh                # build + test (native Rosetta & x87sidecar)

--- a/rosetta_core/include/rosetta_core/Config.h
+++ b/rosetta_core/include/rosetta_core/Config.h
@@ -191,6 +191,11 @@ struct RosettaConfig {
                                     //                  the `DC D8` fcomp alias goes back to
                                     //                  raising an illegal-instruction trap
                                     //                  the way stock Rosetta does.
+    uint8_t loader_no_preauth;      // X87_NO_PREAUTH   skip the pre-launch taskport
+                                    //                  authorization (default attach only);
+                                    //                  the post-exec task_for_pid then asks
+                                    //                  for it while the tracee is frozen at
+                                    //                  its exec stop.
     uint8_t loader_always_none;     // X87_ALWAYS_NONE  diagnostic: sidecar replies None for
                                     //                  every translate_insn request, so the
                                     //                  stub falls through to stock for all

--- a/rosetta_core/src/ConfigEnv.cpp
+++ b/rosetta_core/src/ConfigEnv.cpp
@@ -265,6 +265,7 @@ RosettaConfig load_config_from_env() {
     cfg.loader_logs = env_truthy("X87_LOGS") ? 1 : 0;
     cfg.loader_disable_hook = env_truthy("X87_DISABLE_HOOK") ? 1 : 0;
     cfg.loader_no_decode_hook = env_truthy("X87_NO_DECODE_HOOK") ? 1 : 0;
+    cfg.loader_no_preauth = env_truthy("X87_NO_PREAUTH") ? 1 : 0;
     cfg.loader_always_none = env_truthy("X87_ALWAYS_NONE") ? 1 : 0;
     cfg.loader_log_ops = env_truthy("X87_LOG_OPS") ? 1 : 0;
     cfg.loader_log_throughput = env_truthy("X87_LOG_THROUGHPUT") ? 1 : 0;
@@ -293,6 +294,12 @@ void print_env_help(std::FILE* out) {
         "                                apples-to-apples baseline against the\n"
         "                                optimised path (both have AOT cache +\n"
         "                                interpreter disabled).\n"
+        "  X87_NO_PREAUTH=1              skip the pre-launch developer-tools\n"
+        "                                authorization (default attach only).  The\n"
+        "                                post-exec task_for_pid then prompts for it\n"
+        "                                while the target is frozen at its exec stop,\n"
+        "                                which stalls every other Rosetta launch on\n"
+        "                                the machine until the dialog is answered.\n"
         "  X87_ALWAYS_NONE=1             diagnostic: sidecar always replies None,\n"
         "                                so the stub falls through to stock for every\n"
         "                                request.  Use to A/B whether a freeze is in\n"

--- a/rosetta_loader/CMakeLists.txt
+++ b/rosetta_loader/CMakeLists.txt
@@ -40,7 +40,9 @@ add_executable(x87sidecar
 # mach_exception.cpp includes the generated mach_excServer.h from the build dir.
 target_include_directories(x87sidecar PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(x87sidecar PRIVATE rosetta_core)
+# Security.framework: the pre-launch system.privilege.taskport authorization
+# (AuthorizationCopyRights) in the default attach path.
+target_link_libraries(x87sidecar PRIVATE rosetta_core "-framework Security")
 
 # Two signed artifacts from the one build:
 #

--- a/rosetta_loader/src/guest_pc_map.cpp
+++ b/rosetta_loader/src/guest_pc_map.cpp
@@ -426,9 +426,20 @@ Status resolveInFragment(const Reader& reader, const Fragment& frag, uint64_t ar
 
 }  // namespace
 
+namespace {
+uint64_t g_armTreeRootOffset = kArmTreeRootOffset;
+}  // namespace
+
+void setArmTreeRootOffset(uint64_t offset) {
+    g_armTreeRootOffset = offset;
+}
+uint64_t armTreeRootOffset() {
+    return g_armTreeRootOffset;
+}
+
 Status lookupFragment(const Reader& reader, uint64_t runtimeBase, uint64_t armPc, Fragment& out) {
     uint64_t nodeAddr = 0;
-    if (!reader(runtimeBase + kArmTreeRootOffset, &nodeAddr, sizeof(nodeAddr))) {
+    if (!reader(runtimeBase + g_armTreeRootOffset, &nodeAddr, sizeof(nodeAddr))) {
         return Status::Unavailable;
     }
 

--- a/rosetta_loader/src/guest_pc_map.hpp
+++ b/rosetta_loader/src/guest_pc_map.hpp
@@ -57,8 +57,12 @@ enum class NoGuestReason : uint8_t {
     BeforeFirstBoundary,  ///< inside a translated fragment, before its first mapped boundary
 };
 
-/// Offset of the ARM-keyed fragment tree root within the runtime image.
+/// Offset of the ARM-keyed fragment tree root within the runtime image, as
+/// built in. The loader replaces it with the value it reads out of the
+/// installed runtime (OffsetFinder::armTreeRootOffset_) before sampling starts.
 inline constexpr uint64_t kArmTreeRootOffset = 0x3ba08;
+void setArmTreeRootOffset(uint64_t offset);
+uint64_t armTreeRootOffset();
 
 /// Field offsets within a CodeFragmentMetadata node.  The node is 0xA0 bytes
 /// and everything a lookup needs lies in [kWindowBegin, kWindowEnd), which is

--- a/rosetta_loader/src/main.cpp
+++ b/rosetta_loader/src/main.cpp
@@ -1,3 +1,4 @@
+#include <Security/Authorization.h>
 #include <mach-o/dyld.h>
 #include <mach-o/dyld_images.h>
 #include <mach/mach_vm.h>
@@ -9,6 +10,7 @@
 #include <sys/ptrace.h>
 #include <sys/sysctl.h>
 #include <sys/wait.h>
+#include <unistd.h>
 
 #include <algorithm>
 #include <cctype>
@@ -29,6 +31,7 @@
 
 #include "coop_proto.h"
 #include "dyld_process_info.hpp"
+#include "guest_pc_map.hpp"
 #include "mach_exception.hpp"
 #include "offset_finder.hpp"
 #include "rosetta_core/Config.h"
@@ -36,6 +39,7 @@
 #include "rosetta_core/CoreConfig.h"
 #include "rosetta_core/Opcode.h"
 #include "rosetta_core/OpcodeCompatibility.h"
+#include "rosetta_core/Opcode_26_4.h"
 #include "rosetta_core/ProfileRuntime.h"
 #include "rosetta_core/RosettaCore.h"
 #include "rosetta_core/TranscendentalHelper.h"
@@ -102,6 +106,179 @@ static bool xnuBuildAtLeast(const int* threshold, size_t nThreshold, bool fallba
 // where the debugserver-style detach (detach_golden_gate) is correct; older
 // kernels need the classic detach().
 static const int kGoldenGateXnuBuild[] = {13432, 0, 94, 501, 4};
+
+// The default attach path's post-exec task_for_pid on the translated tracee
+// needs the system.privilege.taskport right, which macOS grants to the login
+// session through a password dialog, once per session. Acquire it here, ahead
+// of launching anything: while that dialog waits, a tracee already frozen at
+// its exec stop stalls every other Rosetta launch on the machine, and it stays
+// stalled after the dialog is answered. The right is shared, so the credential
+// authd caches for this call satisfies the kernel's later check from the
+// sidecar, which is a different process by then.
+static bool preauthorizeTaskport() {
+    AuthorizationRef ref = nullptr;
+    const OSStatus created = AuthorizationCreate(nullptr, kAuthorizationEmptyEnvironment,
+                                                 kAuthorizationFlagDefaults, &ref);
+    if (created != errAuthorizationSuccess) {
+        fprintf(stdout, "[rosettax87] AuthorizationCreate failed (status %d)\n",
+                static_cast<int>(created));
+        return false;
+    }
+    AuthorizationItem item = {"system.privilege.taskport", 0, nullptr, 0};
+    AuthorizationRights rights = {1, &item};
+    // Silent first: succeeds outright when the session already holds the right.
+    OSStatus st = AuthorizationCopyRights(
+        ref, &rights, kAuthorizationEmptyEnvironment,
+        kAuthorizationFlagExtendRights | kAuthorizationFlagPreAuthorize, nullptr);
+    if (st == errAuthorizationInteractionNotAllowed) {
+        fprintf(stdout,
+                "[rosettax87] macOS is asking for developer-tools authorization; enter your "
+                "password in the dialog\n");
+        fflush(stdout);
+        st = AuthorizationCopyRights(
+            ref, &rights, kAuthorizationEmptyEnvironment,
+            kAuthorizationFlagExtendRights | kAuthorizationFlagInteractionAllowed, nullptr);
+    }
+    if (st != errAuthorizationSuccess) {
+        fprintf(stdout, "[rosettax87] system.privilege.taskport not granted (status %d)\n",
+                static_cast<int>(st));
+        return false;
+    }
+    // Deliberately not freed: this process execs into the target right after,
+    // and the cached credential lives in authd, not in the ref.
+    return true;
+}
+
+// NOTE_EXIT watch on the tracee. The sidecar is not its parent, so waitpid is
+// out and kqueue's EVFILT_PROC is the way to learn that it exited. It has to be
+// armed while the tracee is still held (before the detach or the handshake
+// reply): a small target can run to completion during the release itself, and
+// registering on a pid that is already gone fails with ESRCH, after which a
+// wait on the empty queue never returns.
+static int armExitWatch(pid_t pid) {
+    int kq = kqueue();
+    if (kq == -1) {
+        return -1;
+    }
+    struct kevent ev;
+    EV_SET(&ev, pid, EVFILT_PROC, EV_ADD, NOTE_EXIT, 0, nullptr);
+    if (kevent(kq, &ev, 1, nullptr, 0, nullptr) == -1) {
+        fprintf(stdout, "[rosettax87] kevent(NOTE_EXIT, %d): %s\n", pid, strerror(errno));
+        close(kq);
+        return -1;
+    }
+    return kq;
+}
+
+// Block until the watched tracee exits. Without a watch, poll for the pid.
+static void waitExitWatch(int kq, pid_t pid) {
+    if (kq == -1) {
+        while (kill(pid, 0) == 0) {
+            sleep(1);
+        }
+        return;
+    }
+    struct kevent ev;
+    kevent(kq, nullptr, 0, &ev, 1, nullptr);
+    close(kq);
+}
+
+// The stub filter routes an opcode by its host id against two contiguous x87
+// ranges and one synthetic id (stub_asm.cpp). Check the entries those depend
+// on against the runtime's own mnemonic table, so a renumbered runtime is
+// refused instead of misrouting instructions.
+static bool opcodeTableMatches(const std::vector<std::string>& names) {
+    struct Sentinel {
+        uint16_t internal;
+        const char* name;
+    };
+    static const Sentinel kSentinels[] = {
+        {kOpcodeName_aaa, "aaa"},         {kOpcodeName_fcmovb, "fcmovb"},
+        {kOpcodeName_fucomip, "fucomip"}, {kOpcodeName_f2xm1, "f2xm1"},
+        {kOpcodeName_fyl2xp1, "fyl2xp1"}, {kOpcodeName_fxsave, "fxsave"},
+        {kOpcodeName_fxrstor, "fxrstor"}, {kOpcodeName_xsetbv, "xsetbv"},
+    };
+    bool ok = true;
+    for (const auto& s : kSentinels) {
+        const uint16_t host = opcode_internal_to_host(s.internal);
+        if (host >= names.size() || names[host] != s.name) {
+            fprintf(stdout, "[rosettax87] opcode %s: expected host id %u, runtime has %s there\n",
+                    s.name, host, host < names.size() ? names[host].c_str() : "nothing");
+            ok = false;
+        }
+    }
+    // The synthetic ARPL id must not be a real entry of the runtime's table.
+    const uint16_t hostArpl = opcode_internal_to_host(kOpcodeName_arpl);
+    if (hostArpl < names.size() && names[hostArpl] == "arpl") {
+        fprintf(stdout, "[rosettax87] the runtime now defines arpl at id %u\n", hostArpl);
+        ok = false;
+    }
+    return ok;
+}
+
+// The checks every launch runs against the installed Rosetta once the on-disk
+// analysis is done. Prints what failed; the caller decides what that means.
+static bool runtimeAssumptionsHold(const OffsetFinder& f) {
+    bool ok = true;
+    if (f.opcodeNames_.empty()) {
+        fprintf(stdout, "[rosettax87] opcode mnemonic table not found; numbering unchecked\n");
+    } else if (!opcodeTableMatches(f.opcodeNames_)) {
+        fprintf(stdout,
+                "[rosettax87] libRosettaRuntime numbers opcodes differently from this build\n");
+        ok = false;
+    }
+    if (f.translationResultSize_ == 0) {
+        fprintf(stdout, "[rosettax87] TranslationResult size not found; unchecked\n");
+    } else if (f.translationResultSize_ != sidecar::kStockTRSize) {
+        fprintf(stdout, "[rosettax87] TranslationResult is 0x%x bytes, this build expects 0x%zx\n",
+                f.translationResultSize_, sidecar::kStockTRSize);
+        ok = false;
+    }
+    return ok;
+}
+
+// --probe: locate and validate everything in the installed Rosetta, print the
+// report, launch nothing. Exit status 0 means this build can hook this
+// Rosetta with every feature; 1 means something is off (the report says what).
+static int probeRuntime() {
+    OffsetFinder f;
+    const bool runtimeOk = f.determineOffsets();
+    const bool libOk = runtimeOk && f.determineRuntimeOffsets();
+    printf("/usr/libexec/rosetta/runtime: %s\n", runtimeOk ? "ok" : "NOT SUPPORTED");
+    if (runtimeOk) {
+        printf(
+            "  exports_fetch      0x%llx\n  mmap wrapper       0x%llx\n  g_disable_aot      "
+            "0x%llx\n",
+            f.offsetExportsFetch_, f.offsetSvcCallEntry_, f.offsetDisableAot_);
+        printf("  fragment tree root %s0x%llx\n",
+               f.armTreeRootOffset_ ? "" : "not found, sampler uses built-in ",
+               f.armTreeRootOffset_ ? f.armTreeRootOffset_ : guest_pc::kArmTreeRootOffset);
+    }
+    printf("libRosettaRuntime: %s\n", libOk ? "ok" : (runtimeOk ? "NOT SUPPORTED" : "not checked"));
+    if (!libOk) {
+        return 1;
+    }
+    rosetta_core_set_runtime_version(f.runtimeVersion_);
+    printf("  version            0x%llx (%s)\n", f.runtimeVersion_,
+           f.runtimeVersion_ > kVersion_26_4 ? "opcodes identity-mapped" : "26.4 opcode table");
+    printf("  translator_translate %s0x%llx\n",
+           f.offsetTranslatorTranslate_ ? "" : "not exported, ", f.offsetTranslatorTranslate_);
+    printf("  translate_insn     0x%llx (x87 hook)\n", f.offsetTranslateInsn_);
+    if (f.offsetDecodeOpcode_) {
+        printf("  decode_opcode      0x%llx (DC D8 / ARPL hook)\n", f.offsetDecodeOpcode_);
+    } else {
+        printf("  decode_opcode      not located or layout changed: DC D8 and ARPL would trap\n");
+    }
+    printf("  TranslationResult  %s0x%x\n",
+           f.translationResultSize_ ? "" : "size not found; expected ",
+           f.translationResultSize_ ? f.translationResultSize_
+                                    : static_cast<uint32_t>(sidecar::kStockTRSize));
+    printf("  opcode table       %zu entries\n", f.opcodeNames_.size());
+    const bool ok =
+        runtimeAssumptionsHold(f) && f.offsetDecodeOpcode_ != 0 && f.armTreeRootOffset_ != 0;
+    printf("%s\n", ok ? "supported" : "NOT fully supported");
+    return ok ? 0 : 1;
+}
 
 // bootstrap_register2 is a private libSystem symbol (the non-deprecated way to
 // publish a dynamic service name). It isn't in <servers/bootstrap.h>, so declare
@@ -447,10 +624,14 @@ public:
         //    the running task, and suspend only once the SIGSTOP exception is
         //    in hand.
 
-        // 1. PrivateResume: reply to the held BRK so the task runs. (Our "stopped
-        //    at BRK" state is a held Mach exception, not a Mach suspend, so there
-        //    is no task_resume to pair here; just release the exception.)
-        exc_.release();
+        // 1. PrivateResume: reply to the held stop so the task runs. (Our
+        //    "stopped" state is a held Mach exception, not a Mach suspend, so
+        //    there is no task_resume to pair here.) The held stop is a BRK on
+        //    the hook path but the exec SIGTRAP on the passthrough path
+        //    (X87_DISABLE_HOOK=1), and that one must be suppressed on resume,
+        //    not delivered: reply(0) does PT_THUPDATE(0) for a soft signal and
+        //    is a plain reply for a breakpoint.
+        exc_.reply(0);
 
         // 2. Signal(SIGSTOP) on the RUNNING task, then wait for the SIGSTOP to
         //    come back as EXC_SOFT_SIGNAL. Suppress any other soft signal and
@@ -898,6 +1079,7 @@ const unsigned int MuhDebugger::AARCH64_BREAKPOINT = 0xD4200000;
 static void print_loader_usage(const char* prog) {
     std::printf(
         "usage: %s [--cooperative] <program> [program-args...]\n"
+        "       %s --probe\n"
         "\n"
         "Flags:\n"
         "  --cooperative  attach via a voluntary task-port handshake instead of\n"
@@ -907,13 +1089,16 @@ static void print_loader_usage(const char* prog) {
         " env var (set automatically). Needs no\n"
         "                 get-task-allow entitlement, so the binary is notarizable.\n"
         "                 Non-cooperative targets keep using the default path.\n"
+        "  --probe        locate and validate everything this build hooks in the\n"
+        "                 installed Rosetta, print the report and exit; launches\n"
+        "                 nothing. Exit status 0 when fully supported.\n"
         "  --help         print this message and exit\n"
         "\n"
         "Sampling profiler (see also the X87_SAMPLE* variables below, which win\n"
         "over these flags so an app bundle can enable it without touching argv):\n"
         "  --sample=<file>       write a guest-pc sample profile here; enables it\n"
         "  --sample-hz=<rate>    sample rate for the latched thread, default 10000\n"
-        "                        (a sample costs ~10 us: about 1% of a core per kHz)\n"
+        "                        (a sample costs ~10 us: about 1%% of a core per kHz)\n"
         "  --sweep-hz=<rate>     rate at which every thread is swept while\n"
         "                        looking for one to latch onto, default 1000;\n"
         "                        never faster than --sample-hz\n"
@@ -928,7 +1113,7 @@ static void print_loader_usage(const char* prog) {
         "\n"
         "All other configuration is via environment variables:\n"
         "\n",
-        prog);
+        prog, prog);
     print_env_help(stdout);
 }
 
@@ -967,6 +1152,9 @@ int main(int argc, char* argv[]) try {
         return 0;
     }
     bool cooperative = false;
+    if (argi < argc && std::string_view(argv[argi]) == "--probe") {
+        return probeRuntime();
+    }
     if (argi < argc && std::string_view(argv[argi]) == "--cooperative") {
         cooperative = true;
         ++argi;
@@ -1042,6 +1230,68 @@ int main(int argc, char* argv[]) try {
         setenv(X87_COOP_ENV, coopName.c_str(), 1);
     }
 
+    // Locate what we patch by scanning the installed Rosetta binaries on disk.
+    // This runs before anything is launched: a runtime whose code does not
+    // match is unsupported, and the right answer is to say so and not start
+    // the target at all rather than patch guessed addresses.
+    OffsetFinder offsetFinder;
+    if (!offsetFinder.determineOffsets()) {
+        fprintf(stdout,
+                "[rosettax87] unsupported Rosetta: /usr/libexec/rosetta/runtime does not "
+                "match the expected code patterns; not launching %s\n",
+                progArgv[0]);
+        return 1;
+    }
+    VERBOSE_LOG("offset_exports_fetch=%llx offset_svc_call_entry=%llx offset_svc_call_ret=%llx\n",
+                offsetFinder.offsetExportsFetch_, offsetFinder.offsetSvcCallEntry_,
+                offsetFinder.offsetSvcCallRet_);
+    if (!offsetFinder.determineRuntimeOffsets()) {
+        fprintf(stdout,
+                "[rosettax87] unsupported Rosetta: libRosettaRuntime does not match the "
+                "expected code patterns; not launching %s\n",
+                progArgv[0]);
+        return 1;
+    }
+    VERBOSE_LOG("offset_translate_insn=%llx offset_transaction_result_size=%llx\n",
+                offsetFinder.offsetTranslateInsn_, offsetFinder.offsetTransactionResultSize_);
+    VERBOSE_LOG("translator_translate=%llx decode_opcode=%llx tr_size=0x%x arm_tree_root=%llx\n",
+                offsetFinder.offsetTranslatorTranslate_, offsetFinder.offsetDecodeOpcode_,
+                offsetFinder.translationResultSize_, offsetFinder.armTreeRootOffset_);
+
+    // Seed the runtime version (OpcodeCompatibility gates 26.4<->26.5 on it)
+    // from the on-disk Exports.version; the loader never calls
+    // rosetta_core_init(), so it must seed this itself. Set here, before the
+    // fork, so the sidecar inherits it and the checks below can use it.
+    VERBOSE_LOG("Rosetta version: %llx\n", offsetFinder.runtimeVersion_);
+    rosetta_core_set_runtime_version(offsetFinder.runtimeVersion_);
+
+    // What the emitted code and the stub filter assume about this runtime,
+    // checked against the runtime itself rather than trusted.
+    if (!runtimeAssumptionsHold(offsetFinder)) {
+        fprintf(stdout, "[rosettax87] unsupported Rosetta; not launching %s\n", progArgv[0]);
+        return 1;
+    }
+    if (offsetFinder.armTreeRootOffset_ != 0) {
+        if (offsetFinder.armTreeRootOffset_ != guest_pc::kArmTreeRootOffset) {
+            VERBOSE_LOG("fragment tree root moved: 0x%llx (built in: 0x%llx)\n",
+                        offsetFinder.armTreeRootOffset_, guest_pc::kArmTreeRootOffset);
+        }
+        guest_pc::setArmTreeRootOffset(offsetFinder.armTreeRootOffset_);
+    }
+
+    // Default attach only: hold the taskport right before anything is forked
+    // or launched. Root needs no authorization (and headless CI has no dialog),
+    // and cooperative mode never calls task_for_pid. This has to happen here,
+    // in the original process: authd is not reachable from the double-forked
+    // sidecar once launchd has adopted it.
+    if (!cooperative && geteuid() != 0 && !g_cfg.loader_no_preauth && !preauthorizeTaskport()) {
+        fprintf(stdout, "[rosettax87] not launching %s\n", progArgv[0]);
+        return 1;
+    }
+
+    // Nothing buffered may cross the forks below, or it is written twice.
+    fflush(stdout);
+
     int syncPipe[2];
     if (pipe(syncPipe) == -1) {
         fprintf(stdout, "pipe: %s\n", strerror(errno));
@@ -1059,10 +1309,20 @@ int main(int argc, char* argv[]) try {
         // PARENT → tracee: wait until the sidecar has attached/registered, then
         // exec the target (keeps the original pid).
         close(syncPipe[1]);
-        char buf;
-        read(syncPipe[0], &buf, 1);
+        char buf = 0;
+        ssize_t got;
+        // The sidecar's ptrace attach stops this process mid-read, which comes
+        // back as EINTR; the go byte is written after that.
+        while ((got = read(syncPipe[0], &buf, 1)) == -1 && errno == EINTR) {
+        }
         close(syncPipe[0]);
         waitpid(child, nullptr, WNOHANG);  // reap intermediate double-fork child
+        if (got != 1 || buf != 'x') {
+            // The sidecar gave up before attaching (authorization refused, or
+            // it died); there is nothing to trace, so do not run the target.
+            fprintf(stdout, "parent: sidecar did not attach; not launching %s\n", progArgv[0]);
+            return 1;
+        }
         VERBOSE_LOG("parent: launching into program: %s\n", progArgv[0]);
         execv(progArgv[0], progArgv);
         fprintf(stdout, "parent: execv: %s\n", strerror(errno));
@@ -1141,6 +1401,8 @@ int main(int argc, char* argv[]) try {
         }
         if (!dbg.attach(parentPid)) {
             fprintf(stdout, "Failed to attach to parent process\n");
+            write(syncPipe[1], "n", 1);
+            close(syncPipe[1]);
             return 1;
         }
         printf("[rosettax87] attached: %s\n", progArgv[0]);
@@ -1197,24 +1459,6 @@ int main(int argc, char* argv[]) try {
         }
     };
 
-    // Set up offsets dynamically
-    OffsetFinder offsetFinder;
-    // Set default offsets temporarily (or just in case we need to fall back)
-    offsetFinder.setDefaultOffsets();
-    // Search the rosetta runtime binary for offsets.
-    if (offsetFinder.determineOffsets()) {
-        VERBOSE_LOG("Found rosetta runtime offsets successfully!\n");
-        VERBOSE_LOG(
-            "offset_exports_fetch=%llx offset_svc_call_entry=%llx offset_svc_call_ret=%llx\n",
-            offsetFinder.offsetExportsFetch_, offsetFinder.offsetSvcCallEntry_,
-            offsetFinder.offsetSvcCallRet_);
-    }
-    if (offsetFinder.determineRuntimeOffsets()) {
-        VERBOSE_LOG("Found additional rosetta runtime offsets successfully!\n");
-        VERBOSE_LOG("offset_translate_insn=%llx offset_transaction_result_size=%llx\n",
-                    offsetFinder.offsetTranslateInsn_, offsetFinder.offsetTransactionResultSize_);
-    }
-
     static const uint8_t kExportsFetchPat[8] = {0x62, 0x06, 0x40, 0xF9, 0x63, 0x12, 0x40, 0xB9};
     const auto runtimeBase = dbg.findRuntimeMatching(offsetFinder.offsetExportsFetch_,
                                                      kExportsFetchPat, sizeof(kExportsFetchPat));
@@ -1242,16 +1486,10 @@ int main(int argc, char* argv[]) try {
     // run_benchmarks.sh compares against. Release without installing the hook.
     if (g_cfg.loader_disable_hook) {
         VERBOSE_LOG("X87_DISABLE_HOOK=1: passthrough mode; releasing without hook\n");
+        const int exitWatch = armExitWatch(parentPid);
         releaseTracee();
         // Block until parent exits (mirror the post-stub-install path below).
-        int kq = kqueue();
-        if (kq != -1) {
-            struct kevent ev;
-            EV_SET(&ev, parentPid, EVFILT_PROC, EV_ADD, NOTE_EXIT, 0, nullptr);
-            kevent(kq, &ev, 1, nullptr, 0, nullptr);
-            kevent(kq, nullptr, 0, &ev, 1, nullptr);
-            close(kq);
-        }
+        waitExitWatch(exitWatch, parentPid);
         return 0;
     }
 
@@ -1275,19 +1513,25 @@ int main(int argc, char* argv[]) try {
         dbg.disarmThreadBreakpoint();
     }
 
-    // Seed the runtime version (OpcodeCompatibility gates 26.4↔26.5 on it) from
-    // the on-disk Exports.version — no live Exports struct (X19) needed. The
-    // loader never calls rosetta_core_init(), so it must seed this itself.
-    VERBOSE_LOG("Rosetta version: %llx\n", offsetFinder.runtimeVersion_);
-    rosetta_core_set_runtime_version(offsetFinder.runtimeVersion_);
-
-    // Locate translate_insn by its 36-byte prologue signature (both modes; no
-    // X19 / initLibrary offset math). Valid because the barrier above (default)
-    // or the post-init handshake (cooperative) guarantees oah is mapped.
-    uint64_t translateInsnAddr = dbg.scanForPattern(OffsetFinder::kTranslateInsnPattern.data(),
-                                                    OffsetFinder::kTranslateInsnPattern.size());
+    // Locate libRosettaRuntime in the tracee by content: the image whose
+    // bytes at translate_insn's on-disk offset are translate_insn's prologue.
+    // Valid because the barrier above (default) or the post-init handshake
+    // (cooperative) guarantees oah is mapped. Every hook address is then
+    // image base + on-disk offset; a live prologue scan remains the fallback.
+    const uint64_t libBase = dbg.findRuntimeMatching(offsetFinder.offsetTranslateInsn_,
+                                                     offsetFinder.translateInsnPrologue_.data(),
+                                                     offsetFinder.translateInsnPrologue_.size());
+    uint64_t translateInsnAddr = 0;
+    if (libBase != 0) {
+        VERBOSE_LOG("libRosettaRuntime base: 0x%llx\n", libBase);
+        translateInsnAddr = libBase + offsetFinder.offsetTranslateInsn_;
+    } else {
+        fprintf(stdout, "libRosettaRuntime not found by content; scanning for translate_insn\n");
+        translateInsnAddr = dbg.scanForPattern(OffsetFinder::kTranslateInsnPattern.data(),
+                                               OffsetFinder::kTranslateInsnPattern.size());
+    }
     if (translateInsnAddr == 0) {
-        fprintf(stdout, "Failed to locate translate_insn by signature scan\n");
+        fprintf(stdout, "Failed to locate translate_insn\n");
         return 1;
     }
     VERBOSE_LOG("translate_insn (scanned) = 0x%llx\n", translateInsnAddr);
@@ -1303,6 +1547,9 @@ int main(int argc, char* argv[]) try {
     //    @ trailing padding) referencing that port name.
     // 4. COW + mach_vm_write the bytes; restore RX.
     // 5. After detach, run the receive loop alongside kqueue parent-exit.
+    // NOTE_EXIT watch on the tracee, armed inside the install scope before the
+    // release and waited on after it.
+    int exitWatch = -1;
     {
         // translate_insn's live address came from the signature scan above.
         // No live Mach-O header walk, no Exports/init_library math, and no
@@ -1315,6 +1562,14 @@ int main(int argc, char* argv[]) try {
         uint8_t origPrologue[16];
         if (!dbg.readMemory(translateInsnAddr, origPrologue, sizeof(origPrologue))) {
             fprintf(stdout, "M2: failed to read translate_insn prologue at 0x%llx\n",
+                    translateInsnAddr);
+            return 1;
+        }
+        if (memcmp(origPrologue, offsetFinder.translateInsnPrologue_.data(),
+                   sizeof(origPrologue)) != 0) {
+            fprintf(stdout,
+                    "translate_insn bytes at 0x%llx differ from the on-disk image (already "
+                    "patched?); refusing to hook\n",
                     translateInsnAddr);
             return 1;
         }
@@ -1847,15 +2102,42 @@ int main(int argc, char* argv[]) try {
         // it, and the alternative — refusing to attach — would be worse.
         uint64_t decodeEntryAddr = 0;
         uint64_t decodeBlobEnd = padStartAddr + blobs.handler.size();
+        // decode_opcode was located and shape-checked on disk; its live
+        // address is the image base plus that offset, and the live bytes must
+        // still be the on-disk ones. Without an image base, fall back to the
+        // prologue signatures in live memory.
+        auto scanDecodeOpcode = [&]() -> uint64_t {
+            if (offsetFinder.offsetDecodeOpcode_ == 0) {
+                return 0;
+            }
+            if (libBase != 0) {
+                const uint64_t a = libBase + offsetFinder.offsetDecodeOpcode_;
+                uint8_t live[16];
+                if (dbg.readMemory(a, live, sizeof(live)) &&
+                    memcmp(live, offsetFinder.decodeOpcodePrologue_.data(), sizeof(live)) == 0) {
+                    return a;
+                }
+                fprintf(stdout, "M2: decode_opcode bytes at 0x%llx differ from the on-disk image\n",
+                        a);
+                return 0;
+            }
+            for (const auto& [pat, len] :
+                 {std::pair{OffsetFinder::kDecodeOpcodePattern.data(),
+                            OffsetFinder::kDecodeOpcodePattern.size()},
+                  std::pair{OffsetFinder::kDecodeOpcodePatternV2.data(),
+                            OffsetFinder::kDecodeOpcodePatternV2.size()}}) {
+                if (const uint64_t a = dbg.scanForPattern(pat, len)) {
+                    return a;
+                }
+            }
+            return 0;
+        };
         if (g_cfg.loader_no_decode_hook) {
             VERBOSE_LOG("M2: X87_NO_DECODE_HOOK=1: skipping the decode_opcode hook\n");
-        } else if (const uint64_t decodeOpcodeAddr = dbg.scanForPattern(
-                       OffsetFinder::kDecodeOpcodePattern.data(),
-                       OffsetFinder::kDecodeOpcodePattern.size());
-                   decodeOpcodeAddr == 0) {
+        } else if (const uint64_t decodeOpcodeAddr = scanDecodeOpcode(); decodeOpcodeAddr == 0) {
             fprintf(stdout,
-                    "M2: decode_opcode not found by signature scan; the DC D8 fcomp "
-                    "alias will keep trapping\n");
+                    "M2: decode_opcode not located, or its layout changed; the DC D8 fcomp "
+                    "alias and 32-bit ARPL will keep trapping\n");
         } else {
             VERBOSE_LOG("M2: decode_opcode (scanned) = 0x%llx\n", decodeOpcodeAddr);
 
@@ -1938,6 +2220,7 @@ int main(int argc, char* argv[]) try {
         // releases it. The receive thread uses it for mach_vm_read on
         // TranslationResult / IRInstr structs.
         mach_port_t parentTaskPort = dbg.taskPort();
+        exitWatch = armExitWatch(parentPid);
         releaseTracee();
 
         // Spawn the Mach receive thread BEFORE the kqueue wait below so
@@ -1969,24 +2252,16 @@ int main(int argc, char* argv[]) try {
         }
     }
 
-    // Block until the parent (wine) exits. We can't use waitpid since
-    // the parent is not our child, so use kqueue with EVFILT_PROC.
-    int kq = kqueue();
-    if (kq != -1) {
-        struct kevent ev;
-        EV_SET(&ev, parentPid, EVFILT_PROC, EV_ADD, NOTE_EXIT, 0, nullptr);
-        kevent(kq, &ev, 1, nullptr, 0, nullptr);
-        // Block until parent exits
-        kevent(kq, nullptr, 0, &ev, 1, nullptr);
-        // Window after NOTE_EXIT but before kernel reaps the parent task:
-        // mach_vm_read still works against the held task-port send-right.
-        // Use it to pull X87_PROFILE counters back into the .prof file.
-        sidecar::dumpCountersIfEnabled(dbg.taskPort());
-        // The sampler thread is detached, so returning from main would kill it
-        // mid-interval and throw away everything since its last report.
-        sidecar::flushSamplerIfEnabled();
-        close(kq);
-    }
+    // Block until the parent (wine) exits, on the watch armed before the
+    // release above.
+    waitExitWatch(exitWatch, parentPid);
+    // Window after NOTE_EXIT but before kernel reaps the parent task:
+    // mach_vm_read still works against the held task-port send-right.
+    // Use it to pull X87_PROFILE counters back into the .prof file.
+    sidecar::dumpCountersIfEnabled(dbg.taskPort());
+    // The sampler thread is detached, so returning from main would kill it
+    // mid-interval and throw away everything since its last report.
+    sidecar::flushSamplerIfEnabled();
 
     return 0;
 } catch (const std::exception& e) {

--- a/rosetta_loader/src/offset_finder.cpp
+++ b/rosetta_loader/src/offset_finder.cpp
@@ -3,41 +3,246 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstdio>
-#include <fstream>
+#include <cstring>
 #include <functional>
-#include <ios>
-#include <iosfwd>
 #include <iterator>
+#include <string>
+#include <string_view>
 #include <vector>
 
 #include "macho_loader.hpp"
 #include "types.h"
 
-auto OffsetFinder::setDefaultOffsets() -> void {
-    // These are the default offsets for the rosetta runtime that matches MD5 hash:
-    // d7819a04355cd77ff24031800a985c13
+namespace {
 
-    offsetExportsFetch_ = 0xFA8C;  // Just before fetching 'exports' structure pointed by X19 and
-                                   // just after checking rosetta runtime version from header
-    //               LDR X8, [X19]  - X19 'exports' structure address
-    //               MOV X9, #1
-    //               MOVK X9, #0x6A00,LSL#32
-    //               MOVK X9, #1,LSL#48
-    //               CMP X8, X9  // if [X19] < 0x16A0000000001
-    //               B.CS <error version flow>
-    // 62 06 40 F9 - LDR X2, [X19,#8]  <--- halt point for override X19 with new 'export' structure
-    // address 63 12 40 B9 - LDR W3, [X19,#0x10]
+using Image = std::vector<std::uint8_t>;
 
-    offsetSvcCallEntry_ = 0x1998;  // The entry point of a function that trigger BSD syscall 'mmap'
-    // B0 18 80 D2 - MOV X16, #197 <--- start for mmap wrapper
-    // 01 10 00 D4 - SVC 0x80
-    // E1 37 9F 9A - CSET X1, CS
-    // offset: 0x19A4:
-    // C0 03 5F D6 - RET <--- end of function
-    offsetSvcCallRet_ = offsetSvcCallEntry_ + 0xC;  // The return point of the above function
+auto insnAt(const Image& image, std::uint64_t off) -> std::uint32_t {
+    std::uint32_t v = 0;
+    std::memcpy(&v, image.data() + off, sizeof(v));
+    return v;
+}
 
-    offsetTransactionResultSize_ = 0x0BA44;
-    offsetTranslateInsn_ = 0x01A654;
+auto findAll(const Image& image, const std::uint8_t* pat, std::size_t len)
+    -> std::vector<std::uint64_t> {
+    std::vector<std::uint64_t> hits;
+    const std::boyer_moore_searcher searcher(pat, pat + len);
+    auto it = image.begin();
+    while (true) {
+        it = std::search(it, image.end(), searcher);
+        if (it == image.end()) {
+            break;
+        }
+        hits.push_back(static_cast<std::uint64_t>(std::distance(image.begin(), it)));
+        ++it;
+    }
+    return hits;
+}
+
+// A section as [begin, end) file offsets; the whole image when absent.
+struct Range {
+    std::uint64_t begin;
+    std::uint64_t end;
+};
+
+auto sectionRange(const MachoLoader& loader, const char* segment, const char* section) -> Range {
+    if (auto* s = loader.getSection(segment, section)) {
+        return {s->offset, s->offset + s->size};
+    }
+    return {0, loader.buffer_.size()};
+}
+
+// Offset of `name` as a whole NUL-delimited string inside `where`, or 0.
+auto findCString(const Image& image, Range where, std::string_view name) -> std::uint64_t {
+    std::string needle;
+    needle.push_back('\0');
+    needle.append(name);
+    needle.push_back('\0');
+    for (std::uint64_t hit :
+         findAll(image, reinterpret_cast<const std::uint8_t*>(needle.data()), needle.size())) {
+        if (hit + 1 >= where.begin && hit + 1 < where.end) {
+            return hit + 1;
+        }
+    }
+    return 0;
+}
+
+// ADRP: page-relative address of the instruction at `off`.
+auto adrpTarget(std::uint32_t insn, std::uint64_t off) -> std::uint64_t {
+    const std::uint64_t immlo = (insn >> 29) & 0x3;
+    const std::uint64_t immhi = (insn >> 5) & 0x7FFFF;
+    auto imm = static_cast<std::int64_t>((immhi << 2) | immlo) << 12;
+    if (imm & (1LL << 32)) {
+        imm |= ~((1LL << 33) - 1);
+    }
+    return (off & ~0xFFFULL) + static_cast<std::uint64_t>(imm);
+}
+
+auto isAdrp(std::uint32_t insn) -> bool {
+    return (insn & 0x9F000000) == 0x90000000;
+}
+// add xd, xn, #imm12 (no shift)
+auto isAddImm(std::uint32_t insn) -> bool {
+    return (insn & 0xFFC00000) == 0x91000000;
+}
+
+// The `add xd, xn, #lo12` instructions that, together with a preceding
+// `adrp xn`, materialise `target`. Returns the offsets of the adds.
+auto findAdrpAddRefs(const Image& image, Range text, std::uint64_t target)
+    -> std::vector<std::uint64_t> {
+    std::vector<std::uint64_t> refs;
+    for (std::uint64_t off = text.begin; off + 4 <= text.end; off += 4) {
+        const std::uint32_t add = insnAt(image, off);
+        if (!isAddImm(add)) {
+            continue;
+        }
+        const std::uint32_t rn = (add >> 5) & 31;
+        const std::uint64_t lo12 = (add >> 10) & 0xFFF;
+        // The adrp is normally the previous instruction; allow a few in between.
+        for (std::uint64_t back = 4; back <= 32 && off >= text.begin + back; back += 4) {
+            const std::uint32_t adrp = insnAt(image, off - back);
+            if (isAdrp(adrp) && (adrp & 31) == rn) {
+                if (adrpTarget(adrp, off - back) + lo12 == target) {
+                    refs.push_back(off);
+                }
+                break;
+            }
+        }
+    }
+    return refs;
+}
+
+// sub sp, sp, #imm12: the first instruction of every frame-setting prologue.
+auto isSubSpImm(std::uint32_t insn) -> bool {
+    return (insn & 0xFF8003FF) == 0xD10003FF;
+}
+
+// Start of the function containing `ref`: walk back to the nearest
+// `sub sp, sp, #imm`. Function bodies only ever `add sp` (epilogues), so the
+// first `sub sp` met walking backwards is the prologue, including for code
+// laid out after the function's own `ret`.
+auto findFunctionStart(const Image& image, Range text, std::uint64_t ref) -> std::uint64_t {
+    for (std::uint64_t off = ref; off >= text.begin + 4 && ref - off < 0x8000; off -= 4) {
+        if (isSubSpImm(insnAt(image, off))) {
+            return off;
+        }
+    }
+    return 0;
+}
+
+// bl target for the instruction at `off`, or 0.
+auto blTarget(std::uint32_t insn, std::uint64_t off) -> std::uint64_t {
+    if ((insn & 0xFC000000) != 0x94000000) {
+        return 0;
+    }
+    auto imm = static_cast<std::int64_t>(insn & 0x03FFFFFF);
+    if (imm & (1 << 25)) {
+        imm |= ~((1LL << 26) - 1);
+    }
+    return off + static_cast<std::uint64_t>(imm * 4);
+}
+
+struct Export {
+    std::uint64_t fn;
+    std::string name;
+};
+
+// The {fn, name} table __DATA,exports points at (rosetta::runtime::library::*).
+auto readExports(const MachoLoader& loader, const Exports* exports) -> std::vector<Export> {
+    std::vector<Export> out;
+    const Image& image = loader.buffer_;
+    // Pointers carry dyld_chained_ptr_64_rebase metadata in their high bits.
+    std::uint64_t table = exports->x87Exports & 0xFFFFFFFF;
+    for (int i = 0; i < 512 && table + 16 <= image.size(); ++i, table += 16) {
+        std::uint64_t fn = 0;
+        std::uint64_t nm = 0;
+        std::memcpy(&fn, image.data() + table, 8);
+        std::memcpy(&nm, image.data() + table + 8, 8);
+        fn &= 0xFFFFFFFF;
+        nm &= 0xFFFFFFFF;
+        if (fn == 0 || nm == 0 || nm >= image.size()) {
+            break;
+        }
+        const char* s = reinterpret_cast<const char*>(image.data() + nm);
+        out.push_back({fn, std::string(s, strnlen(s, image.size() - nm))});
+    }
+    return out;
+}
+
+}  // namespace
+
+auto prologueIsRelocatable(const std::uint8_t* bytes, std::size_t len) -> bool {
+    for (std::size_t i = 0; i + 4 <= len; i += 4) {
+        std::uint32_t insn = 0;
+        std::memcpy(&insn, bytes + i, 4);
+        if ((insn & 0x1F000000) == 0x10000000 ||  // adr / adrp
+            (insn & 0x7C000000) == 0x14000000 ||  // b / bl
+            (insn & 0xFF000010) == 0x54000000 ||  // b.cond
+            (insn & 0x7E000000) == 0x34000000 ||  // cbz / cbnz
+            (insn & 0x7E000000) == 0x36000000 ||  // tbz / tbnz
+            (insn & 0x3B000000) == 0x18000000) {  // ldr (literal)
+            return false;
+        }
+    }
+    return true;
+}
+
+// What the decode_opcode hook relies on, checked against the function body
+// rather than assumed from a byte signature:
+//   * it opens with `sub sp, sp, #imm` (the 16 displaced bytes are a plain
+//     frame setup, and relocatable);
+//   * within the first 16 instructions, `mov xN, x0` is followed by
+//     `str xzr, [xN, #0x28]!`: the ctx pointer moves to xN, ctx->fault is at
+//     +0x28 and xN becomes ctx+0x28;
+//   * shortly after, `ldp xa, xb, [xN, #-0x20]` loads code_base/code_end from
+//     ctx+0x08/+0x10 and `stp xc, xc, [xN, #-0x10]` seeds insn_start/cursor
+//     at ctx+0x18/+0x20, which is exactly the DecoderCtx layout the hook
+//     swaps and restores (stub_asm.hpp, kDecoderCtx*);
+//   * `str x3, [sp]` stashes out_len in the frame within the first 32
+//     instructions, the calling convention the hook's second call assumes.
+auto decodeOpcodeShapeOk(const std::vector<std::uint8_t>& image, std::uint64_t off) -> bool {
+    if (off == 0 || off + 32 * 4 > image.size()) {
+        return false;
+    }
+    if (!isSubSpImm(insnAt(image, off)) || !prologueIsRelocatable(image.data() + off, 16)) {
+        return false;
+    }
+    std::uint64_t faultStore = 0;
+    std::uint32_t ctxReg = 0;
+    for (std::uint64_t i = 1; i < 16; ++i) {
+        const std::uint32_t mov = insnAt(image, off + i * 4);
+        if ((mov & 0xFFFFFFE0) != 0xAA0003E0) {  // mov xN, x0
+            continue;
+        }
+        const std::uint32_t n = mov & 31;
+        if (insnAt(image, off + (i + 1) * 4) == (0xF8028C1F | (n << 5))) {  // str xzr,[xN,#0x28]!
+            faultStore = off + (i + 1) * 4;
+            ctxReg = n;
+            break;
+        }
+    }
+    if (faultStore == 0) {
+        return false;
+    }
+    bool sawLoadBounds = false;
+    bool sawSeedCursor = false;
+    for (std::uint64_t i = 1; i <= 8; ++i) {
+        const std::uint32_t insn = insnAt(image, faultStore + i * 4);
+        if ((insn & 0xFFFF83E0) == (0xA97E0000 | (ctxReg << 5))) {  // ldp xa, xb, [xN, #-0x20]
+            sawLoadBounds = true;
+        }
+        if ((insn & 0xFFFF83E0) == (0xA93F0000 | (ctxReg << 5)) &&
+            (insn & 31) == ((insn >> 10) & 31)) {  // stp xc, xc, [xN, #-0x10]
+            sawSeedCursor = true;
+        }
+    }
+    bool sawOutLenStash = false;
+    for (std::uint64_t i = 1; i < 32; ++i) {
+        if (insnAt(image, off + i * 4) == 0xF90003E3) {  // str x3, [sp]
+            sawOutLenStash = true;
+        }
+    }
+    return sawLoadBounds && sawSeedCursor && sawOutLenStash;
 }
 
 auto OffsetFinder::determineOffsets() -> bool {
@@ -52,53 +257,35 @@ auto OffsetFinder::determineOffsets() -> bool {
     // For svc_call we need to check where this bitpattern starts in the code and also where it ends
     // (we can just add 0xC to the start to get the end)
 
-    // Load rosetta runtime into an ifstream
-    std::ifstream file{"/usr/libexec/rosetta/runtime", std::ios::binary};
-
-    // Check if we were successfully able to load the file, if not abort and use default offsets
-    if (!file) {
-        fprintf(
-            stdout,
-            "Problem accessing rosetta runtime to determine offsets automatically.\nFalling back "
-            "to macOS 26.0 defaults (This WILL crash your app if they are not correct!)\n");
+    MachoLoader runtime;
+    if (!runtime.open("/usr/libexec/rosetta/runtime")) {
+        fprintf(stdout, "Cannot open /usr/libexec/rosetta/runtime to determine offsets\n");
         return false;
     }
-
-    // Determine size of rosetta runtime file
-    file.seekg(0, std::ios::end);
-    std::streampos size = file.tellg();
-    file.seekg(0, std::ios::beg);
-
-    // Set our buffer to the size of the file
-    std::vector<unsigned char> buffer(size);
-
-    // read into the buffer
-    if (!file.read(reinterpret_cast<char*>(buffer.data()), size)) {
-        fprintf(stdout,
-                "Problem reading rosetta runtime to determine offsets automatically.\nFalling back "
-                "to macOS 26.0 defaults (This WILL crash your app if they are not correct!)\n");
-        return false;
-    }
+    const Image& buffer = runtime.buffer_;
 
     // Do the search and store the results
     std::vector<std::uint64_t> results;
     for (const auto& offset : {exportsFetch, svcCall, disableAot}) {
-        const std::boyer_moore_searcher searcher(offset.begin(), offset.end());
-        const auto it = std::search(buffer.begin(), buffer.end(), searcher);
-        if (it == buffer.end()) {
-            fprintf(stdout, "Offset not found in rosetta runtime binary\n");
+        const auto hits = findAll(buffer, offset.data(), offset.size());
+        if (hits.empty()) {
+            fprintf(stdout, "Pattern %zu not found in /usr/libexec/rosetta/runtime\n",
+                    results.size());
             results.push_back(-1);
         } else {
-            results.push_back(static_cast<std::uint64_t>(std::distance(buffer.begin(), it)));
+            if (hits.size() > 1) {
+                fprintf(stdout,
+                        "Pattern %zu matches %zu places in /usr/libexec/rosetta/runtime; "
+                        "using the first\n",
+                        results.size(), hits.size());
+            }
+            results.push_back(hits[0]);
         }
     }
 
     // If we've stored -1 in any offset, error out and fall back to non-accelerated x87 handles.
     if (static_cast<int>(results[0]) <= -1 || static_cast<int>(results[1]) <= -1 ||
         static_cast<int>(results[2]) <= -1) {
-        fprintf(stdout,
-                "Problem searching rosetta runtime to determine offsets automatically.\nFalling "
-                "back to macOS 26 defaults (This WILL crash your app if they are not correct!)\n");
         return false;
     }
 
@@ -117,36 +304,56 @@ __text:00000000000147B4 08 F1 4F 39                 LDRB            W8, [X8,#dis
     */
     uint32_t adrp_offset = results[2] + 8;
 
-    uint32_t adrp_instruction = reinterpret_cast<uint32_t*>(&buffer[adrp_offset])[0];
-    uint32_t ldrb_instruction = reinterpret_cast<uint32_t*>(&buffer[adrp_offset + 4])[0];
-
-    // Decode ADRP: PC-relative page address
-    // immlo = bits [30:29], immhi = bits [23:5]
-    uint64_t immlo = (adrp_instruction >> 29) & 0x3;
-    uint64_t immhi = (adrp_instruction >> 5) & 0x7FFFF;
-    int64_t imm = static_cast<int64_t>((immhi << 2) | immlo) << 12;
-    // Sign-extend from 33 bits
-    if (imm & (1ULL << 32)) {
-        imm |= ~((1ULL << 33) - 1);
+    uint32_t adrp_instruction = insnAt(buffer, adrp_offset);
+    uint32_t ldrb_instruction = insnAt(buffer, adrp_offset + 4);
+    if (!isAdrp(adrp_instruction) || (ldrb_instruction & 0xFFC00000) != 0x39400000) {
+        fprintf(stdout,
+                "g_disable_aot: unexpected instructions after the anchor in "
+                "/usr/libexec/rosetta/runtime\n");
+        return false;
     }
-
-    uint64_t adrp_page = (adrp_offset & ~0xFFF) + imm;
-
     // Decode LDRB (unsigned offset): pageoff = imm12 (bits [21:10]), no shift for byte access
     uint64_t ldrb_imm12 = (ldrb_instruction >> 10) & 0xFFF;
-    uintptr_t disable_aot_offset = adrp_page + ldrb_imm12;
+    offsetDisableAot_ = adrpTarget(adrp_instruction, adrp_offset) + ldrb_imm12;
 
-    offsetDisableAot_ = disable_aot_offset;
+    // The sampler's fragment lookup: a plain tree search rooted at a global,
+    // which panics with a fixed string when the pc is in no fragment. Find the
+    // string's reference, then the last `adrp xM; add xM, xM, #lo` before it
+    // that does not build the string itself: that is the root. Best effort.
+    const Range text = sectionRange(runtime, "__TEXT", "__text");
+    const Range cstrings = sectionRange(runtime, "__TEXT", "__cstring");
+    if (const std::uint64_t panic =
+            findCString(buffer, cstrings, "cannot locate code fragment for arm address")) {
+        for (const std::uint64_t ref : findAdrpAddRefs(buffer, text, panic)) {
+            for (std::uint64_t back = 4; back <= 64 * 4 && ref >= text.begin + back; back += 4) {
+                const std::uint32_t add = insnAt(buffer, ref - back);
+                if (!isAddImm(add) || (add & 31) != ((add >> 5) & 31) || (add & 31) == 0) {
+                    continue;
+                }
+                const std::uint32_t adrp = insnAt(buffer, ref - back - 4);
+                if (!isAdrp(adrp) || (adrp & 31) != (add & 31)) {
+                    continue;
+                }
+                const std::uint64_t target =
+                    adrpTarget(adrp, ref - back - 4) + ((add >> 10) & 0xFFF);
+                // The root is a global in __DATA or __bss, past __text and
+                // possibly past the end of the file (bss has no file bytes).
+                if (target >= text.end && target < text.end + 0x400000) {
+                    armTreeRootOffset_ = target;
+                }
+                break;
+            }
+            if (armTreeRootOffset_ != 0) {
+                break;
+            }
+        }
+    }
 
     return true;
 }
 
 auto OffsetFinder::determineRuntimeOffsets() -> bool {
     const std::vector<unsigned char> translation_result_size_pattern = {0x01, 0x4D, 0x80, 0x52};
-    const std::vector<unsigned char> translation_pattern = {
-        0xFF, 0x43, 0x03, 0xD1, 0xFC, 0x6F, 0x07, 0xA9, 0xfa, 0x67, 0x08, 0xa9,
-        0xF8, 0x5F, 0x09, 0xA9, 0xF6, 0x57, 0x0A, 0xA9, 0xF4, 0x4F, 0x0B, 0xA9,
-        0xFD, 0x7B, 0x0C, 0xA9, 0xFD, 0x03, 0x03, 0x91, 0xF3, 0x03, 0x00, 0xAA};
 
     MachoLoader libRosettaRuntimeLoader;
     if (!libRosettaRuntimeLoader.open("/Library/Apple/usr/libexec/oah/libRosettaRuntime")) {
@@ -155,6 +362,7 @@ auto OffsetFinder::determineRuntimeOffsets() -> bool {
                 "automatically.\n");
         return false;
     }
+    const Image& image = libRosettaRuntimeLoader.buffer_;
 
     auto* text_section = libRosettaRuntimeLoader.getSection("__TEXT", "__text");
     if (!text_section) {
@@ -163,31 +371,8 @@ auto OffsetFinder::determineRuntimeOffsets() -> bool {
                 "determine runtime offsets automatically.\n");
         return false;
     }
-
-    std::vector<std::uint64_t> results;
-    for (const auto& offset : {translation_result_size_pattern, translation_pattern}) {
-        const std::boyer_moore_searcher searcher(offset.begin(), offset.end());
-        const auto it = std::search(libRosettaRuntimeLoader.buffer_.begin(),
-                                    libRosettaRuntimeLoader.buffer_.end(), searcher);
-        if (it == libRosettaRuntimeLoader.buffer_.end()) {
-            fprintf(stdout, "Offset not found in libRosettaRuntime binary\n");
-            results.push_back(-1);
-        } else {
-            results.push_back(static_cast<std::uint64_t>(
-                std::distance(libRosettaRuntimeLoader.buffer_.begin(), it)));
-        }
-    }
-
-    // If we've stored -1 in any offset, error out and fall back to non-accelerated x87 handles.
-    if (static_cast<int>(results[0]) <= -1 || static_cast<int>(results[1]) <= -1) {
-        fprintf(
-            stdout,
-            "Problem searching libRosettaRuntime to determine runtime offsets automatically.\n");
-        return false;
-    }
-
-    offsetTransactionResultSize_ = results[0];
-    offsetTranslateInsn_ = results[1];
+    const Range text = sectionRange(libRosettaRuntimeLoader, "__TEXT", "__text");
+    const Range cstrings = sectionRange(libRosettaRuntimeLoader, "__TEXT", "__cstring");
 
     auto* exports_section = libRosettaRuntimeLoader.getSection("__DATA", "exports");
     if (!exports_section) {
@@ -196,22 +381,148 @@ auto OffsetFinder::determineRuntimeOffsets() -> bool {
                 "determine runtime offsets automatically.\n");
         return false;
     }
+    auto* exports = reinterpret_cast<const Exports*>(image.data() + exports_section->offset);
 
-    auto* exports = reinterpret_cast<Exports*>(libRosettaRuntimeLoader.buffer_.data() +
-                                               exports_section->offset);
-
-    auto x87_exports_rva =
-        exports->x87Exports &
-        0xFFFFFFFF;  // cut off the upper bits which are used by dyld_chained_ptr_64_rebase
+    const auto x87_exports_rva = exports->x87Exports & 0xFFFFFFFF;
     offsetInitLibrary_ =
-        (*reinterpret_cast<uint64_t*>(libRosettaRuntimeLoader.buffer_.data() + x87_exports_rva)) &
-        0xFFFFFFFF;
+        (*reinterpret_cast<const uint64_t*>(image.data() + x87_exports_rva)) & 0xFFFFFFFF;
 
     // Exports.version is a build constant baked into the on-disk __DATA,exports
-    // (not a rebased pointer), so it reads correctly from the file — no need for
-    // the live Exports struct. Used to seed the runtime version in both attach
-    // modes.
+    // (not a rebased pointer), so it reads correctly from the file. Used to seed
+    // the runtime version in both attach modes.
     runtimeVersion_ = exports->version;
+
+    // translator_translate is exported by name. Its body calls translate_insn
+    // once per instruction and hands its allocator the TranslationResult size
+    // as an immediate, so it anchors both.
+    const auto exportsTable = readExports(libRosettaRuntimeLoader, exports);
+    std::uint64_t ttEnd = 0;
+    for (const auto& e : exportsTable) {
+        if (e.name.find("translator_translateE") != std::string::npos) {
+            offsetTranslatorTranslate_ = e.fn;
+        }
+    }
+    if (offsetTranslatorTranslate_ != 0) {
+        ttEnd = std::min<std::uint64_t>(offsetTranslatorTranslate_ + 0x4000, text.end);
+        for (const auto& e : exportsTable) {
+            if (e.fn > offsetTranslatorTranslate_ && e.fn < ttEnd) {
+                ttEnd = e.fn;
+            }
+        }
+        for (std::uint64_t off = offsetTranslatorTranslate_; off + 4 <= ttEnd; off += 4) {
+            const std::uint32_t insn = insnAt(image, off);
+            if (translationResultSize_ == 0 && (insn & 0xFFE0001F) == 0x52800001) {  // movz w1,#imm
+                translationResultSize_ = (insn >> 5) & 0xFFFF;
+            }
+        }
+    }
+
+    // translate_insn: the callee of translator_translate that names itself
+    // "translate_instruction" in its asserts. The prologue signature is the
+    // fallback and the cross-check.
+    const auto prologueHits =
+        findAll(image, kTranslateInsnPattern.data(), kTranslateInsnPattern.size());
+    std::uint64_t byCaller = 0;
+    if (offsetTranslatorTranslate_ != 0) {
+        std::vector<std::uint64_t> selfRefs;
+        if (const std::uint64_t name = findCString(image, cstrings, "translate_instruction")) {
+            selfRefs = findAdrpAddRefs(image, text, name);
+        }
+        std::vector<std::uint64_t> candidates;
+        for (std::uint64_t off = offsetTranslatorTranslate_; off + 4 <= ttEnd; off += 4) {
+            const std::uint64_t target = blTarget(insnAt(image, off), off);
+            if (target == 0 || target < text.begin || target + 16 > text.end ||
+                !isSubSpImm(insnAt(image, target))) {
+                continue;
+            }
+            const bool namesItself =
+                std::any_of(selfRefs.begin(), selfRefs.end(), [&](std::uint64_t ref) {
+                    return ref > target && ref - target < 0x8000 &&
+                           findFunctionStart(image, text, ref) == target;
+                });
+            if (namesItself &&
+                std::find(candidates.begin(), candidates.end(), target) == candidates.end()) {
+                candidates.push_back(target);
+            }
+        }
+        if (candidates.size() == 1) {
+            byCaller = candidates[0];
+        }
+    }
+    if (byCaller != 0) {
+        offsetTranslateInsn_ = byCaller;
+        if (prologueHits.empty() || prologueHits[0] != byCaller) {
+            fprintf(stdout,
+                    "translate_insn: located at 0x%llx via translator_translate; the prologue "
+                    "signature %s\n",
+                    static_cast<unsigned long long>(byCaller),
+                    prologueHits.empty() ? "no longer matches it" : "matches elsewhere first");
+        }
+    } else if (!prologueHits.empty()) {
+        offsetTranslateInsn_ = prologueHits[0];
+    } else {
+        fprintf(stdout, "translate_insn not found in libRosettaRuntime\n");
+        return false;
+    }
+    std::memcpy(translateInsnPrologue_.data(), image.data() + offsetTranslateInsn_, 16);
+    if (!prologueIsRelocatable(translateInsnPrologue_.data(), 16)) {
+        fprintf(stdout, "translate_insn: its first 16 bytes are not relocatable; cannot hook\n");
+        return false;
+    }
+
+    // The TranslationResult size immediate, kept for the verbose log.
+    if (const auto hits = findAll(image, translation_result_size_pattern.data(),
+                                  translation_result_size_pattern.size());
+        !hits.empty()) {
+        offsetTransactionResultSize_ = hits[0];
+    }
+
+    // decode_opcode: the function that names itself "decode_opcode" in its
+    // asserts, accepted only if it still has the shape the hook relies on.
+    // Falls back to the prologue signatures. Best effort: the hook is optional.
+    if (const std::uint64_t name = findCString(image, cstrings, "decode_opcode")) {
+        for (const std::uint64_t ref : findAdrpAddRefs(image, text, name)) {
+            const std::uint64_t start = findFunctionStart(image, text, ref);
+            if (decodeOpcodeShapeOk(image, start)) {
+                offsetDecodeOpcode_ = start;
+                break;
+            }
+        }
+    }
+    if (offsetDecodeOpcode_ == 0) {
+        for (const auto& [pat, len] :
+             {std::pair{kDecodeOpcodePattern.data(), kDecodeOpcodePattern.size()},
+              std::pair{kDecodeOpcodePatternV2.data(), kDecodeOpcodePatternV2.size()}}) {
+            const auto hits = findAll(image, pat, len);
+            if (hits.size() == 1 && decodeOpcodeShapeOk(image, hits[0])) {
+                offsetDecodeOpcode_ = hits[0];
+                break;
+            }
+        }
+    }
+    if (offsetDecodeOpcode_ != 0) {
+        std::memcpy(decodeOpcodePrologue_.data(), image.data() + offsetDecodeOpcode_, 16);
+    }
+
+    // The opcode mnemonic table, in host enum order: what the runtime's own
+    // module printer uses. Read it whole; the loader checks the entries the
+    // stub filter's opcode ranges depend on against it.
+    static const char kTableHead[] = "\0aaa\0aad\0aam\0aas\0adc\0add\0";
+    const auto heads =
+        findAll(image, reinterpret_cast<const std::uint8_t*>(kTableHead), sizeof(kTableHead) - 1);
+    if (heads.size() == 1) {
+        std::uint64_t p = heads[0] + 1;
+        const std::uint64_t end = std::min<std::uint64_t>(cstrings.end, image.size());
+        while (p < end && opcodeNames_.size() < 1024) {
+            const char* s = reinterpret_cast<const char*>(image.data() + p);
+            const std::size_t n = strnlen(s, end - p);
+            if (n == 0) {
+                break;
+            }
+            opcodeNames_.emplace_back(s, n);
+            p += n + 1;
+        }
+    }
 
     return true;
 }

--- a/rosetta_loader/src/offset_finder.hpp
+++ b/rosetta_loader/src/offset_finder.hpp
@@ -1,49 +1,101 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
-#include <iostream>
+#include <string>
+#include <vector>
 
+// Everything the loader patches or reads inside Rosetta is located here, from
+// the two on-disk images, before anything is launched:
+//
+//   /usr/libexec/rosetta/runtime                     (determineOffsets)
+//   /Library/Apple/usr/libexec/oah/libRosettaRuntime (determineRuntimeOffsets)
+//
+// Both images are position independent with __TEXT at vmaddr 0, so a file
+// offset is also the offset from the live image base.
+//
+// Functions are found by the anchors that survive a rebuild: the export table
+// names `translator_translate`, every function names itself in the string it
+// hands to Rosetta's assert helper, and the opcode mnemonic table is laid out
+// in enum order. Byte-pattern signatures of prologues remain as the fallback
+// and as a cross-check. Whatever is found is then validated structurally: the
+// hook on decode_opcode, for instance, is only installed if the function still
+// keeps the DecoderCtx fields where the hook writes them.
 struct OffsetFinder {
-    auto setDefaultOffsets() -> void;
     auto determineOffsets() -> bool;
     auto determineRuntimeOffsets() -> bool;
 
-    std::uint64_t offsetExportsFetch_;
-    std::uint64_t offsetSvcCallEntry_;
-    std::uint64_t offsetSvcCallRet_;
-    std::uint64_t offsetDisableAot_;
+    // /usr/libexec/rosetta/runtime
+    std::uint64_t offsetExportsFetch_ = 0;
+    std::uint64_t offsetSvcCallEntry_ = 0;
+    std::uint64_t offsetSvcCallRet_ = 0;
+    std::uint64_t offsetDisableAot_ = 0;
+    // Root of the ARM-keyed code-fragment tree the sampler walks, from the
+    // lookup that panics with "cannot locate code fragment for arm address".
+    // 0 when not located (the sampler keeps its built-in value).
+    std::uint64_t armTreeRootOffset_ = 0;
 
-    std::uint64_t offsetTransactionResultSize_;
-    std::uint64_t offsetTranslateInsn_;
-    std::uint64_t offsetInitLibrary_;
+    // libRosettaRuntime
+    std::uint64_t offsetTransactionResultSize_ = 0;
+    std::uint64_t offsetTranslateInsn_ = 0;
+    std::uint64_t offsetInitLibrary_ = 0;
+    std::uint64_t offsetTranslatorTranslate_ = 0;  // exported by name
+    std::uint64_t offsetDecodeOpcode_ = 0;         // 0 when not located or not hookable
+    // Size of the TranslationResult stock allocates, read from the immediate
+    // translator_translate hands its allocator. 0 when not found.
+    std::uint32_t translationResultSize_ = 0;
+    // The first 16 bytes of each hooked function as they are on disk; the live
+    // bytes must match before a hook is written over them.
+    std::array<std::uint8_t, 16> translateInsnPrologue_{};
+    std::array<std::uint8_t, 16> decodeOpcodePrologue_{};
+    // Host opcode id -> mnemonic, from the runtime's own table. Empty when the
+    // table was not found.
+    std::vector<std::string> opcodeNames_;
 
     // Exports.version, read from the on-disk runtime by determineRuntimeOffsets.
-    // Seeds the OpcodeCompatibility layer (26.4↔26.5) without needing the live
-    // Exports struct (X19) — so both attach modes get it the same way.
+    // Seeds the OpcodeCompatibility layer (26.4<->26.5) without needing the live
+    // Exports struct (X19), so both attach modes get it the same way.
     std::uint64_t runtimeVersion_ = 0;
 
     // translate_insn's 36-byte prologue signature (stp/sub-sp/mov prologue).
-    // Unique enough to locate translate_insn in live memory via a content scan,
-    // so we never need the Exports struct to derive its address.
+    // Fallback locator, and what identifies the image in live memory.
     static constexpr std::array<std::uint8_t, 36> kTranslateInsnPattern = {
         0xFF, 0x43, 0x03, 0xD1, 0xFC, 0x6F, 0x07, 0xA9, 0xfa, 0x67, 0x08, 0xa9,
         0xF8, 0x5F, 0x09, 0xA9, 0xF6, 0x57, 0x0A, 0xA9, 0xF4, 0x4F, 0x0B, 0xA9,
         0xFD, 0x7B, 0x0C, 0xA9, 0xFD, 0x03, 0x03, 0x91, 0xF3, 0x03, 0x00, 0xAA};
 
-    // decode_opcode's 44-byte prologue signature.  Rosetta's single-instruction
-    // x86 decoder:
+    // decode_opcode's prologue signatures, the fallback locator.  Rosetta's
+    // single-instruction x86 decoder:
     //   int decode_opcode(DecoderCtx*, unsigned offset, DecodedInsn* out,
     //                     uint8_t* out_len)   -> 0=ok, 1=invalid, 2=fault
     //
-    // The first 32 bytes are a generic 0x70-frame prologue that matches 72
-    // places in the runtime, so the signature has to run through the three
-    // instructions that follow: `str x3, [sp]` (stashing out_len), `mov x24,
-    // x0`, and `str xzr, [x24, #0x28]!` (zeroing ctx->fault, which is also
-    // what pins DecoderCtx's layout).  With those it is unique.
+    // The first 32 bytes are a generic 0x70-frame prologue that matches some
+    // seventy places in the runtime, so a signature has to run through what
+    // follows.  Two layouts exist, both starting with the same 32 bytes and
+    // both ending in `str xzr, [x24, #0x28]!` (zeroing ctx->fault, which is
+    // also what pins DecoderCtx's layout):
+    //
+    //   V1 (runtime version 0x16f0140000000): `str x3, [sp]` (stashing
+    //      out_len), `mov x24, x0`, `str xzr, [x24, #0x28]!`.
+    //   V2 (runtime version 0x16f0200000000): `mov x24, x0`,
+    //      `str xzr, [x24, #0x28]!`; the out_len stash comes later.
     static constexpr std::array<std::uint8_t, 44> kDecodeOpcodePattern = {
-        0xFF, 0xC3, 0x01, 0xD1, 0xFC, 0x6F, 0x01, 0xA9, 0xFA, 0x67, 0x02,
-        0xA9, 0xF8, 0x5F, 0x03, 0xA9, 0xF6, 0x57, 0x04, 0xA9, 0xF4, 0x4F,
-        0x05, 0xA9, 0xFD, 0x7B, 0x06, 0xA9, 0xFD, 0x83, 0x01, 0x91, 0xE3,
-        0x03, 0x00, 0xF9, 0xF8, 0x03, 0x00, 0xAA, 0x1F, 0x8F, 0x02, 0xF8};
+        0xFF, 0xC3, 0x01, 0xD1, 0xFC, 0x6F, 0x01, 0xA9, 0xFA, 0x67, 0x02, 0xA9, 0xF8, 0x5F, 0x03,
+        0xA9, 0xF6, 0x57, 0x04, 0xA9, 0xF4, 0x4F, 0x05, 0xA9, 0xFD, 0x7B, 0x06, 0xA9, 0xFD, 0x83,
+        0x01, 0x91, 0xE3, 0x03, 0x00, 0xF9, 0xF8, 0x03, 0x00, 0xAA, 0x1F, 0x8F, 0x02, 0xF8};
+    static constexpr std::array<std::uint8_t, 40> kDecodeOpcodePatternV2 = {
+        0xFF, 0xC3, 0x01, 0xD1, 0xFC, 0x6F, 0x01, 0xA9, 0xFA, 0x67, 0x02, 0xA9, 0xF8, 0x5F,
+        0x03, 0xA9, 0xF6, 0x57, 0x04, 0xA9, 0xF4, 0x4F, 0x05, 0xA9, 0xFD, 0x7B, 0x06, 0xA9,
+        0xFD, 0x83, 0x01, 0x91, 0xF8, 0x03, 0x00, 0xAA, 0x1F, 0x8F, 0x02, 0xF8};
 };
+
+// True when none of the AArch64 instructions in `bytes` (a multiple of 4)
+// is pc-relative, so the sequence runs unchanged from another address. Both
+// hooks displace the first 16 bytes of their target into a stash and execute
+// them there.
+auto prologueIsRelocatable(const std::uint8_t* bytes, std::size_t len) -> bool;
+
+// True when decode_opcode at `off` in `image` still has the shape the hook
+// relies on (see offset_finder.cpp for the exact checks).
+auto decodeOpcodeShapeOk(const std::vector<std::uint8_t>& image, std::uint64_t off) -> bool;

--- a/rosetta_loader/src/sidecar.cpp
+++ b/rosetta_loader/src/sidecar.cpp
@@ -199,7 +199,8 @@ constexpr size_t kListCount = 6;
 // WoW on nearly every fld block.  The translator only ever touches fields well
 // below 0x268 (insn_buf, fixup lists, free_gpr/fpr masks, thread_context_
 // offsets), so trimming to the real size loses no state.
-constexpr size_t kStockTRSize = 0x268;
+// kStockTRSize lives in sidecar.hpp; the loader checks it against the
+// immediate translator_translate hands its allocator at startup.
 static_assert(kStockTRSize <= offsetof(TranslationResult, x87_cache),
               "stock TR size must not exceed our struct's pre-x87_cache prefix");
 std::mutex g_x87CacheMu;

--- a/rosetta_loader/src/sidecar.hpp
+++ b/rosetta_loader/src/sidecar.hpp
@@ -14,6 +14,11 @@
 // them. M3 will add real translation work + reply.
 namespace sidecar {
 
+// Size of the TranslationResult stock allocates for a translation. Reads and
+// writes of the tracee's TR are bounded by it (writing past it clobbered the
+// adjacent heap chunk holding the block's first emitted ARM word).
+constexpr size_t kStockTRSize = 0x268;
+
 // Mach IPC port plumbing for the inline stub.
 //
 // Two ports are involved:


### PR DESCRIPTION
macOS 27 ships a Rosetta (`libRosettaRuntime` version `0x16f0200000000`) whose `decode_opcode` prologue is laid out differently, so the 44-byte signature that #18 hooks matched nothing and `DC D8` and 32-bit `ARPL` trapped again, with only a line on stdout to say so. The function is unchanged where it matters: DecoderCtx fields, argument registers and the return convention are the same. Locating it by prologue bytes was the weak point, and every other anchor in the loader had the same weakness, so this PR replaces the approach rather than adding one more signature.

The loader now locates what it patches by anchors that survive a rebuild. `translator_translate` is exported by name. `translate_insn` is the callee inside it whose body references the `translate_instruction` assert string, which also settles the two functions sharing its prologue properly instead of by first hit. `decode_opcode` is found the same way through its own name and is only hooked after a structural check proves the DecoderCtx layout from the code. The sampler's fragment-tree root is read from the runtime's lookup code, anchored on its panic string. libRosettaRuntime's live base is found by content, and both hooks compare the live bytes with the on-disk bytes before patching. The prologue signatures stay as the fallback only, with the second `decode_opcode` layout added.

Before the target is launched, the loader checks the assumptions the emitted code relies on against the installed runtime: the opcode numbering behind the stub filter's x87 ranges (from the runtime's own mnemonic table), the TranslationResult size (from the immediate `translator_translate` hands its allocator), and that the bytes each hook displaces are relocatable. A runtime that fails a check is refused with a message instead of patched at guessed addresses; the fallback offsets pinned to an old runtime hash are gone. `x87sidecar --probe` runs that analysis, prints the report and exits 0 only when fully supported. CI now runs it before the tests, so this run is the first look at what the anchors resolve to on the macos-26 image.

Two things the new kernel's timing exposed, both pre-existing: the NOTE_EXIT watch on the tracee was registered after the detach, so a target that finished during the detach left the sidecar waiting forever; and the debugserver-style detach released the held stop with a bare reply, which on the passthrough path (`X87_DISABLE_HOOK=1`) delivered the exec SIGTRAP and killed the tracee. macOS 26 never saw the second one because it takes the classic detach.

The default attach path also acquires the taskport authorization before forking. The post-exec `task_for_pid` used to trigger the developer-tools password dialog while the tracee sat frozen at its exec stop, and every other Rosetta launch on the machine then hung in uninterruptible wait until the dialog was answered. The parent now only execs on the sidecar's go byte and retries its sync read across the attach stop. `X87_NO_PREAUTH=1` skips the pre-flight; root and cooperative mode never needed it.

Verified on macOS 27.0 (xnu-13432.1.9): the full suite passes 968/968 on three consecutive runs, `--probe` reports fully supported, and the sampler resolves every sample. The fallback locators and the refusal paths were not exercised against a real second Rosetta build; CI on macos-26 is the first check against an older runtime.
