### PR TITLE
Reset the X87Cache when stock starts a block over or bypasses the translator

### DIFF
--- a/rosetta_core/include/rosetta_core/X87Cache.h
+++ b/rosetta_core/include/rosetta_core/X87Cache.h
@@ -13,23 +13,16 @@ struct IRInstr;
 // Caching these two values across instructions saves 3-4 emitted AArch64
 // instructions per x87 opcode after the first in a run.
 struct X87Cache {
-    int32_t last_insn_idx = -1;  // Last insn_idx asked for in this block: a
-                                 // stock pass restarting from a smaller or
-                                 // equal index invalidates the mid-run cache
-                                 // state — the code that loaded base/top has
-                                 // been thrown away with the aborted pass.
-    uint64_t last_buf_end = 0;   // insn_buf.end after the last call: on a
-                                 // mid-span re-ask this shows whether stock
-                                 // rolled back our emitted BYTES (end < frontier).
-    int32_t last_next_idx = -1;  // next_idx returned by the last call (the
-                                 // consumption frontier; -1 = None/unknown).
-                                 // A mid-run request with insn_idx != this
-                                 // frontier means stock rolled its pass back
-                                 // INTO an already-consumed span
-                                 // (fusion/peephole/IR run): continuing in
-                                 // register mode would emit the span's tail
-                                 // without its head (observed as faddp
-                                 // without fld1 -> Miles pitch 2^x-1).
+    // Where the previous translate_instruction call in this block entered
+    // (last_insn_idx) and where its reply told stock to continue
+    // (last_next_idx; -1 after a None reply).  Stock walks a block front to
+    // back, so the only continuation of an active run is a request at
+    // exactly last_next_idx.  A request at or before last_insn_idx, or
+    // anywhere else inside an active run, means stock started the block's
+    // translation over: the emitted code that holds base/TOP in registers
+    // is gone, and the cache is reset as on a block change.
+    int32_t last_insn_idx = -1;
+    int32_t last_next_idx = -1;
     int8_t base_gpr = 0;        // GPR holding X87State base
     int8_t top_gpr = 0;         // GPR holding TOP
     int16_t run_remaining = 0;  // Countdown; 0 = inactive

--- a/rosetta_core/include/rosetta_core/X87Cache.h
+++ b/rosetta_core/include/rosetta_core/X87Cache.h
@@ -13,6 +13,23 @@ struct IRInstr;
 // Caching these two values across instructions saves 3-4 emitted AArch64
 // instructions per x87 opcode after the first in a run.
 struct X87Cache {
+    int32_t last_insn_idx = -1;  // Last insn_idx asked for in this block: a
+                                 // stock pass restarting from a smaller or
+                                 // equal index invalidates the mid-run cache
+                                 // state — the code that loaded base/top has
+                                 // been thrown away with the aborted pass.
+    uint64_t last_buf_end = 0;   // insn_buf.end after the last call: on a
+                                 // mid-span re-ask this shows whether stock
+                                 // rolled back our emitted BYTES (end < frontier).
+    int32_t last_next_idx = -1;  // next_idx returned by the last call (the
+                                 // consumption frontier; -1 = None/unknown).
+                                 // A mid-run request with insn_idx != this
+                                 // frontier means stock rolled its pass back
+                                 // INTO an already-consumed span
+                                 // (fusion/peephole/IR run): continuing in
+                                 // register mode would emit the span's tail
+                                 // without its head (observed as faddp
+                                 // without fld1 -> Miles pitch 2^x-1).
     int8_t base_gpr = 0;        // GPR holding X87State base
     int8_t top_gpr = 0;         // GPR holding TOP
     int16_t run_remaining = 0;  // Countdown; 0 = inactive

--- a/rosetta_core/src/Translator.cpp
+++ b/rosetta_core/src/Translator.cpp
@@ -2,10 +2,7 @@
 
 #include <algorithm>
 #include <cstdint>
-#include <unistd.h>
-
 #include <cstdio>
-#include <cstdlib>
 #include <optional>
 
 #include "rosetta_core/AssemblerHelpers.hpp"
@@ -36,8 +33,8 @@ static bool is_x87_opcode(uint16_t op) {
            (op >= kOpcodeName_f2xm1 && op <= kOpcodeName_fyl2xp1);
 }
 
-// Real body; the public translate_instruction wraps it to record the
-// consumed frontier (last_next_idx) after every exit path in one place.
+// Real body.  The public translate_instruction wraps it so the reply's
+// frontier (last_next_idx) is recorded once, after every exit path.
 static auto translate_instruction_impl(TranslationResult* translation_result, IRBlock* block,
                                        IRInstr* instr_array, int64_t num_instrs, int64_t insn_idx)
     -> std::optional<int64_t>;
@@ -47,9 +44,7 @@ auto Translator::translate_instruction(TranslationResult* translation_result, IR
     -> std::optional<int64_t> {
     const auto ret =
         translate_instruction_impl(translation_result, block, instr_array, num_instrs, insn_idx);
-    translation_result->x87_cache.last_next_idx =
-        ret.has_value() ? static_cast<int32_t>(*ret) : -1;
-    translation_result->x87_cache.last_buf_end = translation_result->insn_buf.end;
+    translation_result->x87_cache.last_next_idx = ret.has_value() ? static_cast<int32_t>(*ret) : -1;
     return ret;
 }
 
@@ -66,69 +61,32 @@ static auto translate_instruction_impl(TranslationResult* translation_result, IR
     // Then, if no cache is active, scan ahead to find the length of the current
     // consecutive x87 run.  x87_cache_set_run only activates if run >= 2.
     {
-        // A restart of the same block's translation (the stock pass may
-        // start over from a smaller or equal index) must reset the cache
-        // exactly like a block change: base/top in registers refer to
-        // emitted code of the thrown-away pass.
-        //
-        // Mid-span re-ask: while a run is ACTIVE, the only legitimate
-        // continuation is insn_idx == last_next_idx (the previous call's
-        // consumption frontier).  Any other index means stock rolled its
-        // pass back INTO an already-consumed span (fusion/peephole/IR run)
-        // — the old last_insn_idx comparison does NOT catch this (it holds
-        // the call's entry index, not the frontier: the fld1;faddp pair
-        // enters at idx=6 and returns next=8, so a re-ask at idx=7 looked
-        // like a "continuation" and emitted faddp without fld1, losing the
-        // "+1" of the Miles pitch chain -> mixer #DE).  React like a
-        // restart: full cache reset, memory-based re-emission.
+        // Same block, but not a continuation: stock started the block's
+        // translation over.  Either it asks at or before an index we already
+        // handled, or a run is active and it asks anywhere but the frontier
+        // the previous reply set (a re-ask inside a span a fusion or IR run
+        // consumed).  In both cases the emitted code that holds base/TOP in
+        // registers belongs to a pass stock discarded, so the cache is reset
+        // as on a block change and this op is emitted from memory state.
+        // Neither has been observed in a real run so far; the line below is
+        // there so a run that does hit one says so.
         const bool midspan_reask = block == cache.prev_block && cache.active() &&
                                    cache.last_next_idx >= 0 &&
                                    insn_idx != static_cast<int64_t>(cache.last_next_idx);
         const bool restart_same_block =
             (block == cache.prev_block && insn_idx <= cache.last_insn_idx) || midspan_reask;
-        if (midspan_reask) {
-            static int midspan_count = 0;
-            ++midspan_count;
-            if (midspan_count <= 10 || midspan_count % 100 == 0) {
+        if (restart_same_block) {
+            static int restart_count = 0;
+            ++restart_count;
+            if (restart_count <= 10 || restart_count % 1000 == 0) {
                 std::fprintf(stdout,
-                             "[x87midspan] #%d hash=0x%016llx ask=%lld frontier=%d last_in=%d "
-                             "run=%d st{td=%d tp=%d dp=%d pd=%d} buf_now=%llu buf_last=%llu\n",
-                             midspan_count, static_cast<unsigned long long>(cache.profile_hash),
-                             static_cast<long long>(insn_idx), cache.last_next_idx,
-                             cache.last_insn_idx, static_cast<int>(cache.run_remaining),
-                             static_cast<int>(cache.top_dirty),
-                             static_cast<int>(cache.tag_push_pending),
-                             static_cast<int>(cache.deferred_pop_count),
-                             static_cast<int>(cache.perm_dirty),
-                             static_cast<unsigned long long>(translation_result->insn_buf.end),
-                             static_cast<unsigned long long>(cache.last_buf_end));
+                             "[rosettax87] x87 cache: block hash=0x%016llx translated again "
+                             "(ask=%lld last_in=%d frontier=%d run=%d), resetting cache (#%d)\n",
+                             static_cast<unsigned long long>(cache.profile_hash),
+                             static_cast<long long>(insn_idx), cache.last_insn_idx,
+                             cache.last_next_idx, static_cast<int>(cache.run_remaining),
+                             restart_count);
                 std::fflush(stdout);
-                // A respawned CrossOver game process loses its stdout —
-                // mirror to a per-pid file when X87_DIAG_DIR is set.
-                static FILE* diag = []() -> FILE* {
-                    const char* dir = std::getenv("X87_DIAG_DIR");
-                    if (dir == nullptr || dir[0] == '\0') {
-                        return nullptr;
-                    }
-                    char path[1024];
-                    std::snprintf(path, sizeof(path), "%s/x87midspan.%d.log", dir, getpid());
-                    return std::fopen(path, "a");
-                }();
-                if (diag != nullptr) {
-                    std::fprintf(diag,
-                                 "[x87midspan] #%d hash=0x%016llx ask=%lld frontier=%d last_in=%d "
-                                 "run=%d st{td=%d tp=%d dp=%d pd=%d} buf_now=%llu buf_last=%llu\n",
-                                 midspan_count, static_cast<unsigned long long>(cache.profile_hash),
-                                 static_cast<long long>(insn_idx), cache.last_next_idx,
-                                 cache.last_insn_idx, static_cast<int>(cache.run_remaining),
-                                 static_cast<int>(cache.top_dirty),
-                                 static_cast<int>(cache.tag_push_pending),
-                                 static_cast<int>(cache.deferred_pop_count),
-                                 static_cast<int>(cache.perm_dirty),
-                                 static_cast<unsigned long long>(translation_result->insn_buf.end),
-                                 static_cast<unsigned long long>(cache.last_buf_end));
-                    std::fflush(diag);
-                }
             }
         }
         if (block != cache.prev_block || restart_same_block) {
@@ -145,6 +103,7 @@ static auto translate_instruction_impl(TranslationResult* translation_result, IR
             cache.stock_free_gpr_mask = translation_result->free_gpr_mask;
             translation_result->free_gpr_mask &= kGprScratchMask;
             cache.last_insn_idx = -1;
+            cache.last_next_idx = -1;
             cache.tally_ir = 0;
             cache.tally_peep = 0;
             cache.tally_single = 0;
@@ -216,8 +175,6 @@ static auto translate_instruction_impl(TranslationResult* translation_result, IR
             }
             translation_result->free_gpr_mask &= kGprScratchMask;
         }
-        // Translation progress inside the block: a following call with
-        // idx <= this means the stock pass restarted.
         cache.last_insn_idx = static_cast<int32_t>(insn_idx);
         if (!cache.active()) {
             const bool cache_disabled = g_rosetta_config && g_rosetta_config->disable_x87_cache;

--- a/rosetta_core/src/Translator.cpp
+++ b/rosetta_core/src/Translator.cpp
@@ -2,7 +2,10 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <unistd.h>
+
 #include <cstdio>
+#include <cstdlib>
 #include <optional>
 
 #include "rosetta_core/AssemblerHelpers.hpp"
@@ -33,7 +36,24 @@ static bool is_x87_opcode(uint16_t op) {
            (op >= kOpcodeName_f2xm1 && op <= kOpcodeName_fyl2xp1);
 }
 
+// Real body; the public translate_instruction wraps it to record the
+// consumed frontier (last_next_idx) after every exit path in one place.
+static auto translate_instruction_impl(TranslationResult* translation_result, IRBlock* block,
+                                       IRInstr* instr_array, int64_t num_instrs, int64_t insn_idx)
+    -> std::optional<int64_t>;
+
 auto Translator::translate_instruction(TranslationResult* translation_result, IRBlock* block,
+                                       IRInstr* instr_array, int64_t num_instrs, int64_t insn_idx)
+    -> std::optional<int64_t> {
+    const auto ret =
+        translate_instruction_impl(translation_result, block, instr_array, num_instrs, insn_idx);
+    translation_result->x87_cache.last_next_idx =
+        ret.has_value() ? static_cast<int32_t>(*ret) : -1;
+    translation_result->x87_cache.last_buf_end = translation_result->insn_buf.end;
+    return ret;
+}
+
+static auto translate_instruction_impl(TranslationResult* translation_result, IRBlock* block,
                                        IRInstr* instr_array, int64_t num_instrs, int64_t insn_idx)
     -> std::optional<int64_t> {
     auto* const cur_instr = &instr_array[insn_idx];
@@ -46,7 +66,72 @@ auto Translator::translate_instruction(TranslationResult* translation_result, IR
     // Then, if no cache is active, scan ahead to find the length of the current
     // consecutive x87 run.  x87_cache_set_run only activates if run >= 2.
     {
-        if (block != cache.prev_block) {
+        // A restart of the same block's translation (the stock pass may
+        // start over from a smaller or equal index) must reset the cache
+        // exactly like a block change: base/top in registers refer to
+        // emitted code of the thrown-away pass.
+        //
+        // Mid-span re-ask: while a run is ACTIVE, the only legitimate
+        // continuation is insn_idx == last_next_idx (the previous call's
+        // consumption frontier).  Any other index means stock rolled its
+        // pass back INTO an already-consumed span (fusion/peephole/IR run)
+        // — the old last_insn_idx comparison does NOT catch this (it holds
+        // the call's entry index, not the frontier: the fld1;faddp pair
+        // enters at idx=6 and returns next=8, so a re-ask at idx=7 looked
+        // like a "continuation" and emitted faddp without fld1, losing the
+        // "+1" of the Miles pitch chain -> mixer #DE).  React like a
+        // restart: full cache reset, memory-based re-emission.
+        const bool midspan_reask = block == cache.prev_block && cache.active() &&
+                                   cache.last_next_idx >= 0 &&
+                                   insn_idx != static_cast<int64_t>(cache.last_next_idx);
+        const bool restart_same_block =
+            (block == cache.prev_block && insn_idx <= cache.last_insn_idx) || midspan_reask;
+        if (midspan_reask) {
+            static int midspan_count = 0;
+            ++midspan_count;
+            if (midspan_count <= 10 || midspan_count % 100 == 0) {
+                std::fprintf(stdout,
+                             "[x87midspan] #%d hash=0x%016llx ask=%lld frontier=%d last_in=%d "
+                             "run=%d st{td=%d tp=%d dp=%d pd=%d} buf_now=%llu buf_last=%llu\n",
+                             midspan_count, static_cast<unsigned long long>(cache.profile_hash),
+                             static_cast<long long>(insn_idx), cache.last_next_idx,
+                             cache.last_insn_idx, static_cast<int>(cache.run_remaining),
+                             static_cast<int>(cache.top_dirty),
+                             static_cast<int>(cache.tag_push_pending),
+                             static_cast<int>(cache.deferred_pop_count),
+                             static_cast<int>(cache.perm_dirty),
+                             static_cast<unsigned long long>(translation_result->insn_buf.end),
+                             static_cast<unsigned long long>(cache.last_buf_end));
+                std::fflush(stdout);
+                // A respawned CrossOver game process loses its stdout —
+                // mirror to a per-pid file when X87_DIAG_DIR is set.
+                static FILE* diag = []() -> FILE* {
+                    const char* dir = std::getenv("X87_DIAG_DIR");
+                    if (dir == nullptr || dir[0] == '\0') {
+                        return nullptr;
+                    }
+                    char path[1024];
+                    std::snprintf(path, sizeof(path), "%s/x87midspan.%d.log", dir, getpid());
+                    return std::fopen(path, "a");
+                }();
+                if (diag != nullptr) {
+                    std::fprintf(diag,
+                                 "[x87midspan] #%d hash=0x%016llx ask=%lld frontier=%d last_in=%d "
+                                 "run=%d st{td=%d tp=%d dp=%d pd=%d} buf_now=%llu buf_last=%llu\n",
+                                 midspan_count, static_cast<unsigned long long>(cache.profile_hash),
+                                 static_cast<long long>(insn_idx), cache.last_next_idx,
+                                 cache.last_insn_idx, static_cast<int>(cache.run_remaining),
+                                 static_cast<int>(cache.top_dirty),
+                                 static_cast<int>(cache.tag_push_pending),
+                                 static_cast<int>(cache.deferred_pop_count),
+                                 static_cast<int>(cache.perm_dirty),
+                                 static_cast<unsigned long long>(translation_result->insn_buf.end),
+                                 static_cast<unsigned long long>(cache.last_buf_end));
+                    std::fflush(diag);
+                }
+            }
+        }
+        if (block != cache.prev_block || restart_same_block) {
             cache.invalidate();
             cache.prev_block = block;
             // Stock carries its register-allocator state across the block
@@ -59,6 +144,7 @@ auto Translator::translate_instruction(TranslationResult* translation_result, IR
             // our emits would clobber stock-live values at runtime.
             cache.stock_free_gpr_mask = translation_result->free_gpr_mask;
             translation_result->free_gpr_mask &= kGprScratchMask;
+            cache.last_insn_idx = -1;
             cache.tally_ir = 0;
             cache.tally_peep = 0;
             cache.tally_single = 0;
@@ -130,6 +216,9 @@ auto Translator::translate_instruction(TranslationResult* translation_result, IR
             }
             translation_result->free_gpr_mask &= kGprScratchMask;
         }
+        // Translation progress inside the block: a following call with
+        // idx <= this means the stock pass restarted.
+        cache.last_insn_idx = static_cast<int32_t>(insn_idx);
         if (!cache.active()) {
             const bool cache_disabled = g_rosetta_config && g_rosetta_config->disable_x87_cache;
             if (!cache_disabled) {

--- a/rosetta_loader/src/sidecar.cpp
+++ b/rosetta_loader/src/sidecar.cpp
@@ -2177,6 +2177,28 @@ TranslateOutcome processTranslateRequest(mach_port_t parentTask, const Translate
         tr.x87_cache = g_x87Cache[req.tr_addr];  // default-constructs on first use
     }
 
+    // Any None reply produced WITHOUT running the translator (the early
+    // failure returns below) must not leave the persisted per-TR X87Cache
+    // trusting mid-run registers: stock translates the op itself and
+    // clobbers the GPRs the cache thinks are holding TOP/base, so the next
+    // sidecar-translated op would miscompile.  The translator's own None
+    // paths invalidate in its default case; this guard covers every bypass
+    // in one place.
+    struct CacheBypassGuard {
+        uint64_t tr_addr;
+        bool ran_translator = false;
+        ~CacheBypassGuard() {
+            if (!ran_translator) {
+                std::scoped_lock lk(g_x87CacheMu);
+                auto it = g_x87Cache.find(tr_addr);
+                if (it != g_x87Cache.end()) {
+                    it->second.invalidate();
+                    it->second.prev_block = nullptr;
+                }
+            }
+        }
+    } _bypass_guard{.tr_addr = req.tr_addr};
+
     TransactionalList<Fixup>* lists[kListCount] = {
         &tr.external_fixups, &tr.internal_fixups,  &tr._fixups,
         &tr.field_B0,        &tr.dyld_stub_fixups, &tr.field_1A8,
@@ -2222,12 +2244,26 @@ TranslateOutcome processTranslateRequest(mach_port_t parentTask, const Translate
         bool reuse = !noIrCache && irc.block == req.block && irc.instr_array == req.instr_array &&
                      irc.num_instrs == req.num_instrs && req.insn_idx > irc.last_idx;
         if (reuse) {
-            IRInstr probe;
-            if (!readTranslate(parentTask, req.instr_array + req.insn_idx * sizeof(IRInstr), &probe,
-                         sizeof(probe))) {
+            // Probe a WINDOW, not a single instruction: the translator reads
+            // the whole run's lookahead (fusions, the IR pipeline, bridging
+            // via flag_liveness), so a stale cached tail miscompiles the
+            // block permanently.  The tail can go stale without any
+            // self-modification: IRInstr::flag_liveness depends on the
+            // block's successors and changes on re-decode.  Observed on
+            // Call of Duty 2 as the loss of fld1/faddp in the Miles pow2
+            // pitch chain (resample step 65536*(2^x-1) instead of
+            // 65536*2^x -> #DE in the mixer's division).
+            constexpr uint64_t kProbeWindow = 32;
+            IRInstr probe[kProbeWindow];
+            uint64_t win = req.num_instrs - req.insn_idx;
+            if (win > kProbeWindow) {
+                win = kProbeWindow;
+            }
+            if (!readTranslate(parentTask, req.instr_array + req.insn_idx * sizeof(IRInstr), probe,
+                         win * sizeof(IRInstr))) {
                 return out;
             }
-            reuse = std::memcmp(&probe, &irc.ir[req.insn_idx], sizeof(IRInstr)) == 0;
+            reuse = std::memcmp(probe, &irc.ir[req.insn_idx], win * sizeof(IRInstr)) == 0;
         }
         if (reuse) {
             g_statIrHits.fetch_add(1, std::memory_order_relaxed);
@@ -2322,6 +2358,7 @@ TranslateOutcome processTranslateRequest(mach_port_t parentTask, const Translate
     dumpBlockIfNew(parentTask, reinterpret_cast<uint64_t>(tr.ir_module_data), req.block,
                    localIR, req.num_instrs);
 
+    _bypass_guard.ran_translator = true;
     auto result = Translator::translate_instruction(
         &tr, reinterpret_cast<IRBlock*>(req.block), localIR,
         static_cast<int64_t>(req.num_instrs), static_cast<int64_t>(req.insn_idx));

--- a/rosetta_loader/src/sidecar.cpp
+++ b/rosetta_loader/src/sidecar.cpp
@@ -234,7 +234,7 @@ struct IRCacheEntry {
     uint64_t block = 0;
     uint64_t instr_array = 0;
     uint64_t num_instrs = 0;
-    uint64_t last_idx = 0;
+    uint64_t next_idx = 0;  // where the previous reply told stock to continue
     std::vector<IRInstr> ir;
 };
 std::unordered_map<uint64_t, IRCacheEntry> g_irCache;
@@ -2241,18 +2241,18 @@ TranslateOutcome processTranslateRequest(mach_port_t parentTask, const Translate
     {
         const bool noIrCache =
             g_rosetta_config != nullptr && g_rosetta_config->loader_no_ir_cache != 0U;
+        // Reuse only for a request at or past the frontier the previous
+        // reply set: stock walks a block front to back, so anything behind
+        // it is a pass started over, whose IR may have been re-decoded into
+        // the same array.
         bool reuse = !noIrCache && irc.block == req.block && irc.instr_array == req.instr_array &&
-                     irc.num_instrs == req.num_instrs && req.insn_idx > irc.last_idx;
+                     irc.num_instrs == req.num_instrs && req.insn_idx >= irc.next_idx;
         if (reuse) {
-            // Probe a WINDOW, not a single instruction: the translator reads
-            // the whole run's lookahead (fusions, the IR pipeline, bridging
-            // via flag_liveness), so a stale cached tail miscompiles the
-            // block permanently.  The tail can go stale without any
-            // self-modification: IRInstr::flag_liveness depends on the
-            // block's successors and changes on re-decode.  Observed on
-            // Call of Duty 2 as the loss of fld1/faddp in the Miles pow2
-            // pitch chain (resample step 65536*(2^x-1) instead of
-            // 65536*2^x -> #DE in the mixer's division).
+            // Probe a window, not one instruction: the translator reads the
+            // whole run's lookahead (fusions, the IR pipeline, bridging via
+            // flag_liveness), and flag_liveness is recomputed from the
+            // block's successors on every decode, so the cached tail can go
+            // stale without the guest code changing.
             constexpr uint64_t kProbeWindow = 32;
             IRInstr probe[kProbeWindow];
             uint64_t win = req.num_instrs - req.insn_idx;
@@ -2282,7 +2282,8 @@ TranslateOutcome processTranslateRequest(mach_port_t parentTask, const Translate
             irc.num_instrs = req.num_instrs;
             g_statIrMisses.fetch_add(1, std::memory_order_relaxed);
         }
-        irc.last_idx = req.insn_idx;
+        // Conservative until the reply is known; the Some path below moves it.
+        irc.next_idx = req.insn_idx + 1;
     }
     IRInstr* const localIR = irc.ir.data();
 
@@ -2362,6 +2363,9 @@ TranslateOutcome processTranslateRequest(mach_port_t parentTask, const Translate
     auto result = Translator::translate_instruction(
         &tr, reinterpret_cast<IRBlock*>(req.block), localIR,
         static_cast<int64_t>(req.num_instrs), static_cast<int64_t>(req.insn_idx));
+    if (result.has_value()) {
+        irc.next_idx = result.value();
+    }
 
     // Capture growth state. If insn_buf grew, Translator's grow() abandoned
     // localInsnVec for a calloc'd buffer (we own that and must free it).


### PR DESCRIPTION
Takes over #21 from @sdponomarenko; the first two commits are theirs, the third trims.

Three ways the per-TR X87Cache the sidecar persists could keep trusting registers that no longer hold TOP and base:

A request that fails before reaching the translator (bad TR read, IR read, TCO read) replies None without the translator's default-case invalidate. Stock then translates the op itself while the persisted entry still says a run is active. A scope guard now invalidates the entry whenever a request exits without the translator having run.

Stock asking again at or before an index we already handled in the same block, or, with a run active, anywhere but the frontier the previous reply set. Both mean the block's translation was started over and the code that loaded base/TOP into registers is gone, so the cache resets as on a block change. This also covers stock handing out the same IRBlock allocation for a different block, which the old pointer comparison could not see. Neither has been observed in a real run (#23's own table says the frontier case fired zero times in a crashing run), so this is a backstop, and one rate-limited line on stdout says when it fires.

The per-TR IR cache reused its copy for any request past the last entry index. It now requires a request at or past the previous reply's frontier, which is the condition a restart actually violates, and probes a 32-instruction window instead of one, since flag_liveness is recomputed from the block's successors on every decode.

Left out from #21: last_buf_end, the X87_DIAG_DIR per-pid mirror and the two twelve-argument log blocks. The knobs PR brings one diag helper for both sides instead.

968/968 locally, and none of the test binaries trips the restart line.
