### PR TITLE
Hand listed blocks to stock by IR hash, and make that hash survive an image slide

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Knobs are environment variables read at startup. The most useful ones:
 | `X87_DISABLE_HOOK=1` | Skip the `translate_insn` patch (apples-to-apples baseline against stock Rosetta) |
 | `X87_NO_DECODE_HOOK=1` | Skip the `decode_opcode` patch, so `DC D8` and 32-bit `ARPL` trap the way they do under stock Rosetta |
 | `X87_NO_TCO_CACHE=1` / `X87_NO_IR_CACHE=1` | Disable the sidecar's per-request syscall optimizations (ThreadContextOffsets cache, per-block IR cache); A/B and bisect hatches |
+| `X87_STOCK_HASH_LIST=0xH,…` | Hand the listed blocks to stock Rosetta entirely, keyed by IR-content hash (`profile_analyze --dump-block` prints it). Bisects a suspected per-block miscompile in a live workload and works around one block at no steady-state cost; `X87_STOCK_OPS=f2xm1,…` does the same for every block containing an opcode |
 | `X87_LOGS=1` | Verbose loader logging |
 
 ## License

--- a/rosetta_core/include/rosetta_core/Config.h
+++ b/rosetta_core/include/rosetta_core/Config.h
@@ -121,6 +121,30 @@ struct RosettaConfig {
     // workload.
     std::vector<uint64_t> x87_bridge_hash_list;     // sorted, binary-searched
     std::vector<uint64_t> x87_no_bridge_hash_list;  // sorted, binary-searched
+    // X87_STOCK_HASH_LIST — hand ENTIRE blocks to stock Rosetta by
+    // IR-content hash (same key as the lists above).  Unlike the bridge /
+    // rollback lists this skips the sidecar translator completely for the
+    // listed blocks: every translate request in such a block gets a None
+    // reply, exactly what X87_ALWAYS_NONE does process-wide, but
+    // block-precise.  This is the only per-block exclusion that works under
+    // wow64, where the sidecar sees host-side PCs only and guest-address
+    // range filtering cannot target a guest module.
+    std::vector<uint64_t> x87_stock_hash_list;      // sorted, binary-searched
+
+    // X87_LOG_HASH_LIST — diagnostic: append a timestamped line (uptime
+    // seconds, same clock as WINEDEBUG +timestamp) to the X87_DIAG_DIR file
+    // for every translate request whose block IR-content hash is listed.
+    // Answers "was this block (re)translated near the corruption moment, or
+    // was its code static for minutes" — the translation-side vs
+    // execution-side discriminator.
+    std::vector<uint64_t> x87_log_hash_list;        // sorted, binary-searched
+
+    // X87_STOCK_OPS — hand to stock every block CONTAINING any of the listed
+    // opcodes (comma-separated mnemonic names, e.g. "f2xm1,fscale").  Coarser
+    // than the hash list but robust against hash instability: use it to
+    // localize a miscompile to "blocks with opcode X" in one run, then narrow
+    // by hash.  Resolved to opcode ids at env-parse time.
+    std::vector<uint16_t> x87_stock_ops;            // sorted, binary-searched
     uint8_t force_x87_ir_gate;       // measurement-only flag for tools/profile_analyze: bypass
                                      // the IR-eligibility gate's pre-build refusal conditions
                                      // (run_remaining<3, top_dirty, deferred_pop_count,

--- a/rosetta_core/include/rosetta_core/Config.h
+++ b/rosetta_core/include/rosetta_core/Config.h
@@ -129,7 +129,7 @@ struct RosettaConfig {
     // block-precise.  This is the only per-block exclusion that works under
     // wow64, where the sidecar sees host-side PCs only and guest-address
     // range filtering cannot target a guest module.
-    std::vector<uint64_t> x87_stock_hash_list;      // sorted, binary-searched
+    std::vector<uint64_t> x87_stock_hash_list;  // sorted, binary-searched
 
     // X87_LOG_HASH_LIST — diagnostic: append a timestamped line (uptime
     // seconds, same clock as WINEDEBUG +timestamp) to the X87_DIAG_DIR file
@@ -137,14 +137,19 @@ struct RosettaConfig {
     // Answers "was this block (re)translated near the corruption moment, or
     // was its code static for minutes" — the translation-side vs
     // execution-side discriminator.
-    std::vector<uint64_t> x87_log_hash_list;        // sorted, binary-searched
+    std::vector<uint64_t> x87_log_hash_list;  // sorted, binary-searched
 
     // X87_STOCK_OPS — hand to stock every block CONTAINING any of the listed
     // opcodes (comma-separated mnemonic names, e.g. "f2xm1,fscale").  Coarser
     // than the hash list but robust against hash instability: use it to
     // localize a miscompile to "blocks with opcode X" in one run, then narrow
     // by hash.  Resolved to opcode ids at env-parse time.
-    std::vector<uint16_t> x87_stock_ops;            // sorted, binary-searched
+    std::vector<uint16_t> x87_stock_ops;  // sorted, binary-searched
+
+    // X87_DIAG_DIR — directory for <dir>/x87diag.<pid>.log, where the
+    // sidecar mirrors the X87_LOG_HASH_LIST and X87_STOCK_HASH_LIST lines.
+    // For hosts that lose the process's stdout.  Empty = off.
+    std::string diag_dir;
     uint8_t force_x87_ir_gate;       // measurement-only flag for tools/profile_analyze: bypass
                                      // the IR-eligibility gate's pre-build refusal conditions
                                      // (run_remaining<3, top_dirty, deferred_pop_count,

--- a/rosetta_core/src/ConfigEnv.cpp
+++ b/rosetta_core/src/ConfigEnv.cpp
@@ -216,6 +216,9 @@ RosettaConfig load_config_from_env() {
         std::printf("[rosettax87] X87_LOG_HASH_LIST: %zu unique hashes\n",
                     cfg.x87_log_hash_list.size());
     }
+    if (const char* v = std::getenv("X87_DIAG_DIR"); v != nullptr && v[0] != '\0') {
+        cfg.diag_dir = v;
+    }
     if (const char* v = std::getenv("X87_STOCK_OPS"); v != nullptr && v[0] != '\0') {
         char buf[4096];
         std::strncpy(buf, v, sizeof(buf) - 1);
@@ -429,14 +432,24 @@ void print_env_help(std::FILE* out) {
         "  X87_NO_BRIDGE_HASH_LIST=H,... never bridge the listed blocks (wins over\n"
         "                                the include list)\n"
         "  X87_STOCK_HASH_LIST=H,...     hand the listed blocks to stock Rosetta\n"
-        "                                ENTIRELY (every translate request in a block\n"
+        "                                entirely: every translate request in a block\n"
         "                                whose IR-content hash is listed replies None,\n"
-        "                                as X87_ALWAYS_NONE does process-wide).  The\n"
+        "                                as X87_ALWAYS_NONE does process-wide.  The\n"
         "                                per-block exclusion that works under wow64,\n"
-        "                                where guest-PC filtering cannot see a module\n"
-        "  X87_STOCK_OPS=name,...        hand to stock every block CONTAINING any of\n"
+        "                                where guest-PC filtering cannot see a module.\n"
+        "                                Such a block never reaches the translator, so\n"
+        "                                it has no X87_PROFILE entry or counter\n"
+        "  X87_STOCK_OPS=name,...        hand to stock every block containing any of\n"
         "                                the listed opcodes (mnemonics, e.g. f2xm1);\n"
         "                                coarse one-run localizer, narrow by hash next\n"
+        "  X87_LOG_HASH_LIST=H,...       write an uptime-stamped line per translate\n"
+        "                                request of the listed blocks to the\n"
+        "                                X87_DIAG_DIR file (same clock as WINEDEBUG\n"
+        "                                +timestamp), to place a crash next to the\n"
+        "                                block's last (re)translation\n"
+        "  X87_DIAG_DIR=<dir>            mirror the [x87stock] and [x87trace] lines to\n"
+        "                                <dir>/x87diag.<pid>.log, for hosts that lose\n"
+        "                                the process's stdout (CrossOver respawns)\n"
         "  X87_SAMPLE=<file>             sampling profiler: write a guest-pc sample\n"
         "                                profile here (rosettax87 only).  Setting it\n"
         "                                enables sampling, as X87_PROFILE does for the\n"

--- a/rosetta_core/src/ConfigEnv.cpp
+++ b/rosetta_core/src/ConfigEnv.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "rosetta_core/Config.h"
+#include "rosetta_core/Opcode.h"
 
 namespace {
 
@@ -205,6 +206,47 @@ RosettaConfig load_config_from_env() {
                     cfg.x87_no_bridge_hash_list.size());
     }
 
+    if (const char* v = std::getenv("X87_STOCK_HASH_LIST"); v != nullptr && v[0] != '\0') {
+        parse_hash_list(v, cfg.x87_stock_hash_list);
+        std::printf("[rosettax87] X87_STOCK_HASH_LIST: %zu unique hashes\n",
+                    cfg.x87_stock_hash_list.size());
+    }
+    if (const char* v = std::getenv("X87_LOG_HASH_LIST"); v != nullptr && v[0] != '\0') {
+        parse_hash_list(v, cfg.x87_log_hash_list);
+        std::printf("[rosettax87] X87_LOG_HASH_LIST: %zu unique hashes\n",
+                    cfg.x87_log_hash_list.size());
+    }
+    if (const char* v = std::getenv("X87_STOCK_OPS"); v != nullptr && v[0] != '\0') {
+        char buf[4096];
+        std::strncpy(buf, v, sizeof(buf) - 1);
+        buf[sizeof(buf) - 1] = '\0';
+        char* save = nullptr;
+        for (char* tok = strtok_r(buf, ",", &save); tok != nullptr;
+             tok = strtok_r(nullptr, ",", &save)) {
+            bool found = false;
+            for (size_t op = 0; op < kOpcodeNames.size(); ++op) {
+                if (kOpcodeNames[op] != nullptr && std::strcmp(kOpcodeNames[op], tok) == 0) {
+                    cfg.x87_stock_ops.push_back(static_cast<uint16_t>(op));
+                    found = true;
+                    // No break: a mnemonic may map to several opcode ids
+                    // (Rosetta assigns per-encoding ids); list them all.
+                }
+            }
+            if (!found) {
+                std::printf("[rosettax87] X87_STOCK_OPS: unknown opcode '%s' (ignored)\n", tok);
+            }
+        }
+        std::ranges::sort(cfg.x87_stock_ops);
+        const auto dup = std::ranges::unique(cfg.x87_stock_ops);
+        cfg.x87_stock_ops.erase(dup.begin(), dup.end());
+        std::printf("[rosettax87] X87_STOCK_OPS: %zu opcode ids resolved:",
+                    cfg.x87_stock_ops.size());
+        for (const uint16_t op : cfg.x87_stock_ops) {
+            std::printf(" 0x%x", static_cast<unsigned>(op));
+        }
+        std::printf("\n");
+    }
+
     if (env_truthy("X87_DISABLE_ALL_FUSIONS")) {
         cfg.disabled_fusions_mask = ~0ULL;
     }
@@ -386,6 +428,15 @@ void print_env_help(std::FILE* out) {
         "                                or profile_analyze)\n"
         "  X87_NO_BRIDGE_HASH_LIST=H,... never bridge the listed blocks (wins over\n"
         "                                the include list)\n"
+        "  X87_STOCK_HASH_LIST=H,...     hand the listed blocks to stock Rosetta\n"
+        "                                ENTIRELY (every translate request in a block\n"
+        "                                whose IR-content hash is listed replies None,\n"
+        "                                as X87_ALWAYS_NONE does process-wide).  The\n"
+        "                                per-block exclusion that works under wow64,\n"
+        "                                where guest-PC filtering cannot see a module\n"
+        "  X87_STOCK_OPS=name,...        hand to stock every block CONTAINING any of\n"
+        "                                the listed opcodes (mnemonics, e.g. f2xm1);\n"
+        "                                coarse one-run localizer, narrow by hash next\n"
         "  X87_SAMPLE=<file>             sampling profiler: write a guest-pc sample\n"
         "                                profile here (rosettax87 only).  Setting it\n"
         "                                enables sampling, as X87_PROFILE does for the\n"

--- a/rosetta_core/src/ProfileRuntime.cpp
+++ b/rosetta_core/src/ProfileRuntime.cpp
@@ -132,6 +132,10 @@ uint64_t hash_ir_stream(const IRInstr* instrs, size_t num_instrs) {
     //   - used operands rebuilt field-by-field per kind: the union's dead
     //     value fields (IROperandRegister::_unused et al.) and pad bytes
     //     carry the same per-run garbage.
+    //   - absolute addresses (AbsMem, which is what rip-relative lea/mov
+    //     decode to, and fixup-carrying Immediates) keep only their page
+    //     offset: the image slides by whole pages between launches, so the
+    //     low 12 bits are the part of the address that survives ASLR.
     // Zeroing only `pc` (the old behaviour) left that garbage in the hash
     // input, so the hash was NOT stable across launches — which silently
     // broke every cross-run use of X87_*_HASH_LIST and profile_analyze
@@ -166,14 +170,15 @@ uint64_t hash_ir_stream(const IRInstr* instrs, size_t num_instrs) {
                         canon.abs_mem.kind = src.abs_mem.kind;
                         canon.abs_mem.size = src.abs_mem.size;
                         canon.abs_mem.addr_size = src.abs_mem.addr_size;
-                        canon.abs_mem.value = src.abs_mem.value;
+                        canon.abs_mem.value = src.abs_mem.value & 0xfff;
                         break;
                     case IROperandKind::Immediate:
                         canon.imm.kind = src.imm.kind;
                         canon.imm.size = src.imm.size;
                         canon.imm.addr_size = src.imm.addr_size;
                         canon.imm.mem_flags = src.imm.mem_flags;
-                        canon.imm.value = src.imm.value;
+                        canon.imm.value =
+                            src.imm.mem_flags != 0 ? (src.imm.value & 0xfff) : src.imm.value;
                         break;
                     case IROperandKind::BranchOffset:
                         canon.branch.kind = src.branch.kind;

--- a/rosetta_loader/src/sidecar.cpp
+++ b/rosetta_loader/src/sidecar.cpp
@@ -2398,14 +2398,11 @@ TranslateOutcome processTranslateRequest(mach_port_t parentTask, const Translate
     const bool haveLogHashes =
         g_rosetta_config != nullptr && !g_rosetta_config->x87_log_hash_list.empty();
     if (haveStockHashes || haveStockOps || haveLogHashes) {
-        uint64_t block_hash = 0;
-        if (haveStockHashes || haveLogHashes) {
-            if (!irc.hash_valid) {
-                irc.hash = profile::hash_ir_stream(localIR, req.num_instrs);
-                irc.hash_valid = true;
-            }
-            block_hash = irc.hash;
+        if (!irc.hash_valid) {
+            irc.hash = profile::hash_ir_stream(localIR, req.num_instrs);
+            irc.hash_valid = true;
         }
+        const uint64_t block_hash = irc.hash;
         if (haveLogHashes &&
             std::ranges::binary_search(g_rosetta_config->x87_log_hash_list, block_hash)) {
             static int log_hits = 0;

--- a/rosetta_loader/src/sidecar.cpp
+++ b/rosetta_loader/src/sidecar.cpp
@@ -235,9 +235,29 @@ struct IRCacheEntry {
     uint64_t instr_array = 0;
     uint64_t num_instrs = 0;
     uint64_t next_idx = 0;  // where the previous reply told stock to continue
+    uint64_t hash = 0;      // profile::hash_ir_stream of ir, when hash_valid
+    bool hash_valid = false;
     std::vector<IRInstr> ir;
 };
 std::unordered_map<uint64_t, IRCacheEntry> g_irCache;
+
+// X87_DIAG_DIR=<dir>: append diagnostic lines to <dir>/x87diag.<pid>.log.
+// Some hosts (CrossOver respawning the game process, for one) lose the
+// process's stdout entirely; a per-pid file is the one channel out of that
+// process's sidecar that survives.  Opened on first use; nullptr, and every
+// caller a no-op, when the knob is unset.
+FILE* diagLog() {
+    static FILE* f = []() -> FILE* {
+        if (g_rosetta_config == nullptr || g_rosetta_config->diag_dir.empty()) {
+            return nullptr;
+        }
+        char path[1024];
+        std::snprintf(path, sizeof(path), "%s/x87diag.%d.log", g_rosetta_config->diag_dir.c_str(),
+                      getpid());
+        return std::fopen(path, "a");
+    }();
+    return f;
+}
 
 // NOTE on the road not taken: mach_vm_remap(copy=FALSE) of TRACEE-owned pages
 // into the sidecar (to turn the TR / insn-buf / fixup reads and writes below
@@ -2280,6 +2300,7 @@ TranslateOutcome processTranslateRequest(mach_port_t parentTask, const Translate
             irc.block = req.block;
             irc.instr_array = req.instr_array;
             irc.num_instrs = req.num_instrs;
+            irc.hash_valid = false;
             g_statIrMisses.fetch_add(1, std::memory_order_relaxed);
         }
         // Conservative until the reply is known; the Some path below moves it.
@@ -2359,12 +2380,90 @@ TranslateOutcome processTranslateRequest(mach_port_t parentTask, const Translate
     dumpBlockIfNew(parentTask, reinterpret_cast<uint64_t>(tr.ir_module_data), req.block,
                    localIR, req.num_instrs);
 
-    _bypass_guard.ran_translator = true;
-    auto result = Translator::translate_instruction(
-        &tr, reinterpret_cast<IRBlock*>(req.block), localIR,
-        static_cast<int64_t>(req.num_instrs), static_cast<int64_t>(req.insn_idx));
-    if (result.has_value()) {
-        irc.next_idx = result.value();
+    // X87_STOCK_HASH_LIST / X87_STOCK_OPS hand whole blocks to stock, by
+    // IR-content hash (profile::hash_ir_stream, the key the bridge and
+    // rollback lists use) or by contained opcode.  Under wow64 the sidecar
+    // sees host-side PCs only, so content is the one per-block selector
+    // that can target a guest module's code.  Requests arrive on
+    // (re)translation, never per execution, so this is cold path; the hash
+    // is still computed once per IR-cache fill rather than per request.
+    // X87_LOG_HASH_LIST writes an uptime-stamped line per request for the
+    // listed blocks (the clock WINEDEBUG=+timestamp prints), so a crash
+    // moment in a wine log can be put next to the block's last translation.
+    bool stock_hash_hit = false;
+    const bool haveStockHashes =
+        g_rosetta_config != nullptr && !g_rosetta_config->x87_stock_hash_list.empty();
+    const bool haveStockOps =
+        g_rosetta_config != nullptr && !g_rosetta_config->x87_stock_ops.empty();
+    const bool haveLogHashes =
+        g_rosetta_config != nullptr && !g_rosetta_config->x87_log_hash_list.empty();
+    if (haveStockHashes || haveStockOps || haveLogHashes) {
+        uint64_t block_hash = 0;
+        if (haveStockHashes || haveLogHashes) {
+            if (!irc.hash_valid) {
+                irc.hash = profile::hash_ir_stream(localIR, req.num_instrs);
+                irc.hash_valid = true;
+            }
+            block_hash = irc.hash;
+        }
+        if (haveLogHashes &&
+            std::ranges::binary_search(g_rosetta_config->x87_log_hash_list, block_hash)) {
+            static int log_hits = 0;
+            ++log_hits;
+            if (log_hits <= 1000 || log_hits % 100 == 0) {
+                const double up =
+                    static_cast<double>(clock_gettime_nsec_np(CLOCK_UPTIME_RAW)) / 1e9;
+                if (FILE* df = diagLog()) {
+                    fprintf(df, "[x87trace] up=%.3f hit#%d hash=0x%016llx idx=%llu/%llu tr=%llx\n",
+                            up, log_hits, static_cast<unsigned long long>(block_hash),
+                            static_cast<unsigned long long>(req.insn_idx),
+                            static_cast<unsigned long long>(req.num_instrs),
+                            static_cast<unsigned long long>(req.tr_addr));
+                    fflush(df);
+                }
+            }
+        }
+        if (haveStockHashes) {
+            stock_hash_hit =
+                std::ranges::binary_search(g_rosetta_config->x87_stock_hash_list, block_hash);
+        }
+        if (!stock_hash_hit && haveStockOps) {
+            for (uint64_t i = 0; i < req.num_instrs && !stock_hash_hit; ++i) {
+                stock_hash_hit = std::ranges::binary_search(g_rosetta_config->x87_stock_ops,
+                                                            localIR[i].opcode());
+            }
+        }
+        if (stock_hash_hit) {
+            static int stock_hits = 0;
+            ++stock_hits;
+            if (stock_hits <= 5 || stock_hits % 1000 == 0) {
+                char line[160];
+                snprintf(line, sizeof(line), "[x87stock] hit #%d hash=0x%016llx idx=%llu/%llu\n",
+                         stock_hits, static_cast<unsigned long long>(block_hash),
+                         static_cast<unsigned long long>(req.insn_idx),
+                         static_cast<unsigned long long>(req.num_instrs));
+                fputs(line, stdout);
+                fflush(stdout);
+                if (FILE* df = diagLog()) {
+                    fputs(line, df);
+                    fflush(df);
+                }
+            }
+        }
+    }
+
+    // On a stock hit ran_translator stays false and the bypass guard
+    // invalidates the persisted X87Cache, which is what a None reply that
+    // skipped the translator needs.
+    std::optional<int64_t> result;
+    if (!stock_hash_hit) {
+        _bypass_guard.ran_translator = true;
+        result = Translator::translate_instruction(
+            &tr, reinterpret_cast<IRBlock*>(req.block), localIR,
+            static_cast<int64_t>(req.num_instrs), static_cast<int64_t>(req.insn_idx));
+        if (result.has_value()) {
+            irc.next_idx = result.value();
+        }
     }
 
     // Capture growth state. If insn_buf grew, Translator's grow() abandoned
@@ -2552,7 +2651,10 @@ TranslateOutcome processTranslateRequest(mach_port_t parentTask, const Translate
             kOpcodeName_fxrstor,  // SSE-era extended
         };
         const uint16_t op = localIR[req.insn_idx].opcode();
-        const bool deliberate = std::ranges::find(kKnownFallThrough, op) != kKnownFallThrough.end();
+        // stock_hash_hit: the None reply is a deliberate whole-block
+        // exclusion, not a missing handler.
+        const bool deliberate = stock_hash_hit ||
+                                std::ranges::find(kKnownFallThrough, op) != kKnownFallThrough.end();
         if (!deliberate) {
             const char* name = (op < kOpcodeNames.size()) ? kOpcodeNames[op] : "?";
             fprintf(stdout,


### PR DESCRIPTION
Takes over #22 from @sdponomarenko; their commit is kept, two more sit on top. Stacked on #26 (the bypass guard is what makes a None reply that skipped the translator safe), so the diff includes #26 until that lands.

Knobs, all keyed by the IR-content hash the bridge and rollback lists already use. X87_STOCK_HASH_LIST=0xH,... replies None for every translate request in a listed block, which is X87_ALWAYS_NONE for one block. It is the per-block exclusion that works under wow64, where the sidecar sees host PCs only, and it is the validated workaround for #23 (2.5 h of play, controls crash within minutes). X87_STOCK_OPS=f2xm1,... does the same for every block containing a listed opcode, as a one-run localiser. X87_LOG_HASH_LIST=0xH,... writes an uptime-stamped line per request of a listed block, on the clock WINEDEBUG=+timestamp prints, so a crash can be placed next to the block's last translation. X87_DIAG_DIR=<dir> mirrors those lines to <dir>/x87diag.<pid>.log for hosts that lose the process's stdout.

While wiring this up I found the hash was still not launch-stable here. #20 zeroes the dead bytes, but rip-relative lea and mov decode to an AbsMem operand holding the absolute guest address, which slides with the image on every launch: the same test binary hashed differently three times in a row, and the block's four lea instructions were the only ones whose canonical form changed. AbsMem values and fixup-carrying immediates now contribute only their page offset, the part of an address that survives a page-granular slide. Under wine the guest modules apparently sat still between runs, which is why #20 looked complete there.

Changes to #22 itself: the hash is computed once per IR-cache fill instead of per request and is printed on X87_STOCK_OPS hits too; X87_DIAG_DIR is a config field read in load_config_from_env and the single opener lives in the loader; the help text covers all four knobs and says that a stock-forced block has no X87_PROFILE entry; the README knob table gets a row.

Verified on test_fmul: three runs give the same hash, profile_analyze --dump-block-by-hash finds a live hash in a fresh capture, the hash list, trace list and diag file fire with a live hash, the test passes with its block handed to stock, and no file appears without X87_DIAG_DIR. 968/968.
