### PR TITLE
Resume the tracee after detach on Tahoe 26.6.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build-and-test:
     runs-on: macos-26
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -31,4 +32,11 @@ jobs:
         # via an interactive system dialog on first launch — not available
         # in headless CI, would hang the job) or root.  GitHub's macos-26
         # runners give passwordless sudo, so just use that.
-        run: sudo scripts/run_tests.sh --no-build
+        run: sudo python3 scripts/diagnose_ci.py --output-dir build/ci-diagnostics -- bash scripts/run_tests.sh --no-build
+
+      - name: Upload test diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-diagnostics
+          path: build/ci-diagnostics

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,15 +27,12 @@ jobs:
         # validates the assumptions behind them; exits non-zero if any is off.
         run: build/bin/x87sidecar --probe
 
-      - name: Run attach diagnostic
-        run: sudo python3 scripts/diagnose_ci.py --idle-timeout 40 --total-timeout 120 --output-dir build/ci-diagnostics/attach -- env X87_LOGS=1 build/bin/x87sidecar_entitled build/bin/tests/test_fldconst
-
       - name: Run tests
         # PT_ATTACH on macOS needs either the debugger entitlement (granted
         # via an interactive system dialog on first launch — not available
         # in headless CI, would hang the job) or root.  GitHub's macos-26
         # runners give passwordless sudo, so just use that.
-        run: sudo python3 scripts/diagnose_ci.py --output-dir build/ci-diagnostics/suite -- bash scripts/run_tests.sh --no-build
+        run: sudo python3 scripts/diagnose_ci.py --output-dir build/ci-diagnostics -- bash scripts/run_tests.sh --no-build
 
       - name: Upload test diagnostics
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,15 @@ jobs:
         # validates the assumptions behind them; exits non-zero if any is off.
         run: build/bin/x87sidecar --probe
 
+      - name: Run attach diagnostic
+        run: sudo python3 scripts/diagnose_ci.py --idle-timeout 40 --total-timeout 120 --output-dir build/ci-diagnostics/attach -- env X87_LOGS=1 build/bin/x87sidecar_entitled build/bin/tests/test_fldconst
+
       - name: Run tests
         # PT_ATTACH on macOS needs either the debugger entitlement (granted
         # via an interactive system dialog on first launch — not available
         # in headless CI, would hang the job) or root.  GitHub's macos-26
         # runners give passwordless sudo, so just use that.
-        run: sudo python3 scripts/diagnose_ci.py --output-dir build/ci-diagnostics -- bash scripts/run_tests.sh --no-build
+        run: sudo python3 scripts/diagnose_ci.py --output-dir build/ci-diagnostics/suite -- bash scripts/run_tests.sh --no-build
 
       - name: Upload test diagnostics
         if: always()

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ bash scripts/run_tests.sh test_arith     # one test
 bash scripts/run_benchmarks.sh           # build + benchmark table
 ```
 
-The harness runs 89 self-checking x86-64 test binaries under stock Rosetta
+The harness runs 90 self-checking x86-64 test binaries under stock Rosetta
 and then under the sidecar in ten configurations (default, IR off, fusions
 off, hook bypassed, FMA contraction on, clamped register pool, pressure
 relief off, fast rounding, bridging off, bridging v2 off), plus a

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -30,6 +30,29 @@ semantics: the two views diverge in both directions. Sharing works only in
 the opposite direction, for pages the sidecar allocates and remaps into the
 tracee, which is exactly how the block profiler's counter array is wired.
 
+## Releasing the default attach stop
+
+The default loader attaches with `PT_ATTACHEXC`, so its stops arrive as
+Mach exceptions. Dropping the ptrace attachment and replying to the held
+exception are separate operations. On macOS 26.6.2 (XNU 12377.161.14), the
+classic sequence successfully detached, but the target stopped again after
+the reply to the synthetic SIGSTOP. The sidecar then waited for the stopped
+target to exit. This reproduced on unchanged master after the CI runner
+moved from macOS 26.5.2 to 26.6.2.
+
+That Tahoe kernel family now uses the same reply-before-detach sequence as
+newer Golden Gate kernels: catch SIGSTOP, hold a Mach task suspend, suppress
+and reply to the signal while still traced, restore exception ports,
+attempt ptrace detach, then balance the task suspend. Older Tahoe builds and early Golden
+Gate kernels retain their existing sequence. The Tahoe cutoff is the
+verified build, not a claim about the first build to change this behavior.
+
+`test_detach_signals` checks that a released target can receive SIGUSR1 in
+its own handler without involving x87 arithmetic. CI also watches the test
+harness for stalled output and captures process state, pipe descriptors and
+stack samples before terminating a stalled invocation. A timeout fails the
+run even if the test PID exited but a sidecar still holds stdout open.
+
 ## Asynchronous signals inside emitted code
 
 When a signal is delivered to a thread that is executing translated code,

--- a/rosetta_loader/src/main.cpp
+++ b/rosetta_loader/src/main.cpp
@@ -1,4 +1,5 @@
 #include <Security/Authorization.h>
+#include <libproc.h>
 #include <mach-o/dyld.h>
 #include <mach-o/dyld_images.h>
 #include <mach/mach_vm.h>
@@ -305,6 +306,30 @@ private:
     MachExceptionSession exc_;
     MachExceptionSession::Event lastEvent_{};
 
+    void logStopState(const char* stage) {
+        if (!logsEnabled) {
+            return;
+        }
+        proc_bsdinfo proc{};
+        int bytes = proc_pidinfo(childPid_, PROC_PIDTBSDINFO, 0, &proc, sizeof(proc));
+        task_basic_info_64_data_t task{};
+        mach_msg_type_number_t taskCount = TASK_BASIC_INFO_64_COUNT;
+        kern_return_t taskResult = task_info(taskPort_, TASK_BASIC_INFO_64,
+                                             reinterpret_cast<task_info_t>(&task), &taskCount);
+        thread_basic_info_data_t thread{};
+        mach_msg_type_number_t threadCount = THREAD_BASIC_INFO_COUNT;
+        kern_return_t threadResult = thread_info(lastEvent_.thread, THREAD_BASIC_INFO,
+                                                 reinterpret_cast<thread_info_t>(&thread),
+                                                 &threadCount);
+        printf("[detach] %s pid=%d bsd_bytes=%d bsd_status=%u traced=%d "
+               "task_result=%d task_suspend=%d thread_result=%d thread_run=%d "
+               "thread_suspend=%d event=%d signal=%d\n", stage, childPid_, bytes,
+               proc.pbi_status, !!(proc.pbi_flags & PROC_FLAG_TRACED), taskResult,
+               task.suspend_count, threadResult, thread.run_state, thread.suspend_count,
+               lastEvent_.type, lastEvent_.softSignal());
+        fflush(stdout);
+    }
+
     // Receive the next event, suppressing soft-signal stops other than
     // expectedSignal (0 = return on any stop), mirroring the old
     // suppress-and-continue loop. An EXC_BREAKPOINT is always a stop. An
@@ -557,6 +582,7 @@ public:
     }
 
     bool detach() {
+        logStopState("classic begin");
         // PT_DETACH requires the tracee to be in a BSD signal-stop. Under
         // PT_ATTACHEXC our stops arrive as Mach exceptions (the BRK is a bare
         // EXC_BREAKPOINT carrying no signal), which PT_DETACH rejects with
@@ -576,17 +602,21 @@ public:
             fprintf(stdout, "detach: failed to reach SIGSTOP stop\n");
             return false;
         }
+        logStopState("classic SIGSTOP received");
         // Restore the task's exception ports, PT_DETACH from the held SIGSTOP
         // stop, then release the exception (unblocking the thread). Order
         // matters: PT_DETACH must run while the SIGSTOP exception is still held,
         // and the release must run after (ptrace is no longer valid post-detach).
         exc_.restoreAndTearDown();
+        logStopState("classic ports restored");
         bool ok = true;
         if (ptrace(PT_DETACH, childPid_, reinterpret_cast<caddr_t>(1), 0) < 0) {
             fprintf(stdout, "ptrace(PT_DETACH): %s\n", strerror(errno));
             ok = false;
         }
+        logStopState("classic PT_DETACH returned");
         exc_.release();
+        logStopState("classic exception released");
         if (ok) {
             VERBOSE_LOG("Debugger detached.\n");
         }
@@ -1199,6 +1229,9 @@ int main(int argc, char* argv[]) try {
     static RosettaConfig g_cfg = load_config_from_env();
     rosetta_set_config(&g_cfg);
     logsEnabled = g_cfg.loader_logs ? "1" : nullptr;
+    if (logsEnabled) {
+        setvbuf(stdout, nullptr, _IONBF, 0);
+    }
 
     VERBOSE_LOG("Launching debugger.\n");
 

--- a/rosetta_loader/src/main.cpp
+++ b/rosetta_loader/src/main.cpp
@@ -107,6 +107,11 @@ static bool xnuBuildAtLeast(const int* threshold, size_t nThreshold, bool fallba
 // where the debugserver-style detach (detach_golden_gate) is correct; older
 // kernels need the classic detach().
 static const int kGoldenGateXnuBuild[] = {13432, 0, 94, 501, 4};
+// Tahoe 26.6.2 also needs the reply-before-detach ordering. Keep the
+// exception to that XNU family so it does not include early Golden Gate
+// kernels that still require the classic path.
+static const int kTahoeResumeFirstXnuBuild[] = {12377, 161, 14};
+static const int kAfterTahoeXnuBuild[] = {12378};
 
 // The default attach path's post-exec task_for_pid on the translated tracee
 // needs the system.privilege.taskport right, which macOS grants to the login
@@ -624,6 +629,7 @@ public:
     }
 
     bool detachGoldenGate() {
+        logStopState("resume-first begin");
         // Exact 1:1 port of lldb debugserver's MachProcess::Detach()
         // (llvm lldb/tools/debugserver/source/MacOSX/MachProcess.mm). Order:
         //
@@ -693,6 +699,7 @@ public:
         //     of the bundle). This is the balanced counterpart to m_task.Resume()
         //     at the end. It freezes the task at Mach level while we tear down.
         task_suspend(taskPort_);
+        logStopState("resume-first SIGSTOP suspended");
 
         // 3. ReplyToAllExceptions: reply to the SIGSTOP exception WHILE STILL
         //    TRACED. reply(0) does PT_THUPDATE(0) to suppress the signal and
@@ -701,9 +708,11 @@ public:
         //    SSTOP cleanly, so no dangling stop is left for a future signal to
         //    wedge on. (The task stays frozen by the Mach suspend from 2b.)
         exc_.reply(0);
+        logStopState("resume-first SIGSTOP replied");
 
         // 4. ShutDownExceptionThread: restore original exception ports, drop ours.
         exc_.restoreAndTearDown();
+        logStopState("resume-first ports restored");
 
         // 5. PT_DETACH, best-effort, exactly as debugserver treats it (it logs
         //    the return but never requires success). Because step 3 SRUN'd the
@@ -716,11 +725,13 @@ public:
         if (ptrace(PT_DETACH, childPid_, reinterpret_cast<caddr_t>(1), 0) < 0 && errno != EBUSY) {
             fprintf(stdout, "ptrace(PT_DETACH): %s\n", strerror(errno));
         }
+        logStopState("resume-first PT_DETACH returned");
 
         // 6. m_task.Resume(): balance the task_suspend from 2b. This is what
         //    actually runs the process; no SIGCONT is needed because the SSTOP was
         //    already lifted by the reply-while-traced in step 3.
         task_resume(taskPort_);
+        logStopState("resume-first task resumed");
 
         VERBOSE_LOG("Debugger detached (golden gate path).\n");
         return true;
@@ -1482,8 +1493,12 @@ int main(int argc, char* argv[]) try {
             // (forces SIG_DFL on all signals, freezing signal-driven GUI apps),
             // so those use the classic detach().
             if (xnuBuildAtLeast(kGoldenGateXnuBuild,
-                                sizeof(kGoldenGateXnuBuild) / sizeof(kGoldenGateXnuBuild[0]))) {
-                VERBOSE_LOG("Using detachGoldenGate (xnu >= 13432.0.94.501.4)\n");
+                               sizeof(kGoldenGateXnuBuild) / sizeof(kGoldenGateXnuBuild[0])) ||
+                (xnuBuildAtLeast(kTahoeResumeFirstXnuBuild,
+                                sizeof(kTahoeResumeFirstXnuBuild) /
+                                    sizeof(kTahoeResumeFirstXnuBuild[0])) &&
+                 !xnuBuildAtLeast(kAfterTahoeXnuBuild, 1))) {
+                VERBOSE_LOG("Using reply-before-detach ordering\n");
                 (void)dbg.detachGoldenGate();
             } else {
                 VERBOSE_LOG("Using classic detach (xnu < 13432.0.94.501.4)\n");

--- a/rosetta_loader/src/main.cpp
+++ b/rosetta_loader/src/main.cpp
@@ -1,5 +1,4 @@
 #include <Security/Authorization.h>
-#include <libproc.h>
 #include <mach-o/dyld.h>
 #include <mach-o/dyld_images.h>
 #include <mach/mach_vm.h>
@@ -103,9 +102,8 @@ static bool xnuBuildAtLeast(const int* threshold, size_t nThreshold, bool fallba
     return true;
 }
 
-// XNU build 13432.0.94.501.4~1 (Golden Gate Dev Beta 4) is the first kernel
-// where the debugserver-style detach (detach_golden_gate) is correct; older
-// kernels need the classic detach().
+// Golden Gate uses the debugserver-style detach from this XNU build.
+// Earlier Golden Gate kernels need the classic detach().
 static const int kGoldenGateXnuBuild[] = {13432, 0, 94, 501, 4};
 // Tahoe 26.6.2 also needs the reply-before-detach ordering. Keep the
 // exception to that XNU family so it does not include early Golden Gate
@@ -310,30 +308,6 @@ private:
     // docs/investigations/ci-flaky-sigtrap-attach.md).
     MachExceptionSession exc_;
     MachExceptionSession::Event lastEvent_{};
-
-    void logStopState(const char* stage) {
-        if (!logsEnabled) {
-            return;
-        }
-        proc_bsdinfo proc{};
-        int bytes = proc_pidinfo(childPid_, PROC_PIDTBSDINFO, 0, &proc, sizeof(proc));
-        task_basic_info_64_data_t task{};
-        mach_msg_type_number_t taskCount = TASK_BASIC_INFO_64_COUNT;
-        kern_return_t taskResult = task_info(taskPort_, TASK_BASIC_INFO_64,
-                                             reinterpret_cast<task_info_t>(&task), &taskCount);
-        thread_basic_info_data_t thread{};
-        mach_msg_type_number_t threadCount = THREAD_BASIC_INFO_COUNT;
-        kern_return_t threadResult = thread_info(lastEvent_.thread, THREAD_BASIC_INFO,
-                                                 reinterpret_cast<thread_info_t>(&thread),
-                                                 &threadCount);
-        printf("[detach] %s pid=%d bsd_bytes=%d bsd_status=%u traced=%d "
-               "task_result=%d task_suspend=%d thread_result=%d thread_run=%d "
-               "thread_suspend=%d event=%d signal=%d\n", stage, childPid_, bytes,
-               proc.pbi_status, !!(proc.pbi_flags & PROC_FLAG_TRACED), taskResult,
-               task.suspend_count, threadResult, thread.run_state, thread.suspend_count,
-               lastEvent_.type, lastEvent_.softSignal());
-        fflush(stdout);
-    }
 
     // Receive the next event, suppressing soft-signal stops other than
     // expectedSignal (0 = return on any stop), mirroring the old
@@ -587,7 +561,6 @@ public:
     }
 
     bool detach() {
-        logStopState("classic begin");
         // PT_DETACH requires the tracee to be in a BSD signal-stop. Under
         // PT_ATTACHEXC our stops arrive as Mach exceptions (the BRK is a bare
         // EXC_BREAKPOINT carrying no signal), which PT_DETACH rejects with
@@ -607,29 +580,24 @@ public:
             fprintf(stdout, "detach: failed to reach SIGSTOP stop\n");
             return false;
         }
-        logStopState("classic SIGSTOP received");
         // Restore the task's exception ports, PT_DETACH from the held SIGSTOP
         // stop, then release the exception (unblocking the thread). Order
         // matters: PT_DETACH must run while the SIGSTOP exception is still held,
         // and the release must run after (ptrace is no longer valid post-detach).
         exc_.restoreAndTearDown();
-        logStopState("classic ports restored");
         bool ok = true;
         if (ptrace(PT_DETACH, childPid_, reinterpret_cast<caddr_t>(1), 0) < 0) {
             fprintf(stdout, "ptrace(PT_DETACH): %s\n", strerror(errno));
             ok = false;
         }
-        logStopState("classic PT_DETACH returned");
         exc_.release();
-        logStopState("classic exception released");
         if (ok) {
             VERBOSE_LOG("Debugger detached.\n");
         }
         return ok;
     }
 
-    bool detachGoldenGate() {
-        logStopState("resume-first begin");
+    bool detachReplyFirst() {
         // Exact 1:1 port of lldb debugserver's MachProcess::Detach()
         // (llvm lldb/tools/debugserver/source/MacOSX/MachProcess.mm). Order:
         //
@@ -699,7 +667,6 @@ public:
         //     of the bundle). This is the balanced counterpart to m_task.Resume()
         //     at the end. It freezes the task at Mach level while we tear down.
         task_suspend(taskPort_);
-        logStopState("resume-first SIGSTOP suspended");
 
         // 3. ReplyToAllExceptions: reply to the SIGSTOP exception WHILE STILL
         //    TRACED. reply(0) does PT_THUPDATE(0) to suppress the signal and
@@ -708,11 +675,9 @@ public:
         //    SSTOP cleanly, so no dangling stop is left for a future signal to
         //    wedge on. (The task stays frozen by the Mach suspend from 2b.)
         exc_.reply(0);
-        logStopState("resume-first SIGSTOP replied");
 
         // 4. ShutDownExceptionThread: restore original exception ports, drop ours.
         exc_.restoreAndTearDown();
-        logStopState("resume-first ports restored");
 
         // 5. PT_DETACH, best-effort, exactly as debugserver treats it (it logs
         //    the return but never requires success). Because step 3 SRUN'd the
@@ -725,15 +690,13 @@ public:
         if (ptrace(PT_DETACH, childPid_, reinterpret_cast<caddr_t>(1), 0) < 0 && errno != EBUSY) {
             fprintf(stdout, "ptrace(PT_DETACH): %s\n", strerror(errno));
         }
-        logStopState("resume-first PT_DETACH returned");
 
         // 6. m_task.Resume(): balance the task_suspend from 2b. This is what
         //    actually runs the process; no SIGCONT is needed because the SSTOP was
         //    already lifted by the reply-while-traced in step 3.
         task_resume(taskPort_);
-        logStopState("resume-first task resumed");
 
-        VERBOSE_LOG("Debugger detached (golden gate path).\n");
+        VERBOSE_LOG("Debugger detached (reply-first path).\n");
         return true;
     }
 
@@ -1240,9 +1203,6 @@ int main(int argc, char* argv[]) try {
     static RosettaConfig g_cfg = load_config_from_env();
     rosetta_set_config(&g_cfg);
     logsEnabled = g_cfg.loader_logs ? "1" : nullptr;
-    if (logsEnabled) {
-        setvbuf(stdout, nullptr, _IONBF, 0);
-    }
 
     VERBOSE_LOG("Launching debugger.\n");
 
@@ -1487,11 +1447,10 @@ int main(int argc, char* argv[]) try {
                         mach_error_string(kr));
             }
         } else {
-            // Pick the detach path by kernel version. detachGoldenGate() (a 1:1
-            // port of debugserver's MachProcess::Detach) is correct only on
-            // new-enough XNU; on older kernels it leaves the tracee P_LTRACED
-            // (forces SIG_DFL on all signals, freezing signal-driven GUI apps),
-            // so those use the classic detach().
+            // Both kernel families need reply-before-detach from the verified
+            // builds below. Earlier builds retain the classic sequence; using
+            // reply-first there leaves the tracee P_LTRACED and interferes
+            // with later signal delivery.
             if (xnuBuildAtLeast(kGoldenGateXnuBuild,
                                sizeof(kGoldenGateXnuBuild) / sizeof(kGoldenGateXnuBuild[0])) ||
                 (xnuBuildAtLeast(kTahoeResumeFirstXnuBuild,
@@ -1499,9 +1458,9 @@ int main(int argc, char* argv[]) try {
                                     sizeof(kTahoeResumeFirstXnuBuild[0])) &&
                  !xnuBuildAtLeast(kAfterTahoeXnuBuild, 1))) {
                 VERBOSE_LOG("Using reply-before-detach ordering\n");
-                (void)dbg.detachGoldenGate();
+                (void)dbg.detachReplyFirst();
             } else {
-                VERBOSE_LOG("Using classic detach (xnu < 13432.0.94.501.4)\n");
+                VERBOSE_LOG("Using classic detach\n");
                 (void)dbg.detach();
             }
         }

--- a/scripts/diagnose_ci.py
+++ b/scripts/diagnose_ci.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Run a command with a deadline and capture its processes before cleanup."""
+
+import argparse
+import json
+import os
+from pathlib import Path
+import selectors
+import signal
+import subprocess
+import sys
+import time
+
+
+def capture(path, command, timeout=10):
+    try:
+        result = subprocess.run(command, stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT, timeout=timeout)
+        path.write_bytes(result.stdout)
+        return result.stdout.decode(errors="replace")
+    except subprocess.TimeoutExpired as error:
+        path.write_bytes((error.stdout or b"") + b"\nDiagnostic command timed out\n")
+    except OSError as error:
+        path.write_text(str(error) + "\n")
+    return ""
+
+
+def processes(group):
+    result = subprocess.run(
+        ["ps", "-axo", "pid=,ppid=,pgid=,stat=,etime=,command="],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=5)
+    result.check_returncode()
+    return [line for line in result.stdout.splitlines()
+            if len(line.split()) >= 3 and line.split()[2] == str(group)]
+
+
+def diagnose(output, group):
+    try:
+        rows = processes(group)
+    except (OSError, subprocess.SubprocessError) as error:
+        (output / "processes.txt").write_text(str(error) + "\n")
+        return
+    (output / "processes.txt").write_text("\n".join(rows) + "\n")
+    print("PID PPID PGID STAT ELAPSED COMMAND", flush=True)
+    for row in rows:
+        print(row, flush=True)
+    # The double-forked sidecar keeps its process group after launchd adopts
+    # it. Looking only for descendants of the harness would miss that process.
+    for row in rows:
+        pid = row.split()[0]
+        capture(output / f"fds-{pid}.txt", ["lsof", "-a", "-p", pid, "-d", "0,1,2"])
+        print(f"Sampling pid {pid}", flush=True)
+        capture(output / f"sample-{pid}-status.txt",
+                ["sample", pid, "1", "1", "-file", str(output / f"sample-{pid}.txt")])
+
+
+def kill_group(group):
+    try:
+        os.killpg(group, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--idle-timeout", type=float, default=90)
+    parser.add_argument("--total-timeout", type=float, default=600)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    command = args.command
+    if command[:1] == ["--"]:
+        command = command[1:]
+    if not command or args.idle_timeout <= 0 or args.total_timeout <= 0:
+        parser.error("a command and positive timeouts are required")
+    output = args.output_dir.resolve()
+    # Do not overwrite evidence from an earlier invocation.
+    output.mkdir(parents=True)
+    capture(output / "os-version.txt", ["sw_vers"])
+    capture(output / "kernel.txt", ["uname", "-a"])
+    (output / "command.json").write_text(json.dumps(command) + "\n")
+
+    started = last_output = last_progress = time.monotonic()
+    process = subprocess.Popen(command, stdout=subprocess.PIPE,
+                               stderr=subprocess.STDOUT, start_new_session=True)
+    print(f"Watching pid/group {process.pid}; evidence: {output}", flush=True)
+    selector = selectors.DefaultSelector()
+    selector.register(process.stdout, selectors.EVENT_READ)
+    eof = False
+    reason = "completed"
+    status_before_cleanup = None
+    try:
+        with (output / "output.log").open("wb", buffering=0) as log:
+            while True:
+                status_before_cleanup = process.poll()
+                if eof and status_before_cleanup is not None:
+                    break
+                now = time.monotonic()
+                if now - started >= args.total_timeout:
+                    reason = "total_timeout"
+                    break
+                if now - last_output >= args.idle_timeout:
+                    reason = "idle_timeout"
+                    break
+                if now - last_progress >= 15:
+                    print(f"Still watching pid/group {process.pid}: "
+                          f"exit={status_before_cleanup}, stdout_eof={eof}, "
+                          f"idle={now - last_output:.1f}s", flush=True)
+                    last_progress = now
+                for key, _ in selector.select(0.1):
+                    data = os.read(key.fd, 65536)
+                    if data:
+                        last_output = time.monotonic()
+                        log.write(data)
+                        sys.stdout.buffer.write(data)
+                        sys.stdout.buffer.flush()
+                    else:
+                        eof = True
+                        selector.unregister(key.fileobj)
+        if reason != "completed":
+            print(f"Diagnostic failure: {reason}; direct exit="
+                  f"{status_before_cleanup}, stdout_eof={eof}", flush=True)
+            diagnose(output, process.pid)
+    finally:
+        # Only this invocation's group is owned by the watchdog. Capture its
+        # state before ending it, including when the original PID exited but
+        # an orphan still holds the output pipe open.
+        if reason != "completed" or sys.exc_info()[0] is not None:
+            kill_group(process.pid)
+        selector.close()
+        process.stdout.close()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            reason = "cleanup_timeout"
+            print("Process did not exit after cleanup", flush=True)
+
+    (output / "result.json").write_text(json.dumps({
+        "pid": process.pid,
+        "reason": reason,
+        "exit_before_cleanup": status_before_cleanup,
+        "returncode": process.returncode,
+        "stdout_eof": eof,
+        "seconds": time.monotonic() - started,
+    }, indent=2) + "\n")
+    if reason != "completed":
+        return 124
+    return process.returncode if process.returncode >= 0 else 128 - process.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -58,6 +58,7 @@ TESTS_BIN="$BIN/tests"
 
 ALL_TESTS=(
     test_fldconst
+    test_detach_signals
     test_fld
     test_fld_m80fp
     test_fmul

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(X86_SAMPLE_OUTPUT_DIR "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/tests")
 
 add_x86_sample(test_fldconst)
+add_x86_sample(test_detach_signals)
 add_x86_sample(test_fld)
 add_x86_sample(test_fld_m80fp)
 add_x86_sample(test_fmul)

--- a/tests/test_detach_signals.c
+++ b/tests/test_detach_signals.c
@@ -1,0 +1,31 @@
+#include <signal.h>
+#include <stdio.h>
+
+static volatile sig_atomic_t handled;
+
+static void handle_signal(int signal) {
+    if (signal == SIGUSR1) {
+        ++handled;
+    }
+}
+
+int main(void) {
+    struct sigaction action = {0};
+    action.sa_handler = handle_signal;
+    sigemptyset(&action.sa_mask);
+    if (sigaction(SIGUSR1, &action, NULL) != 0) {
+        puts("FAIL install SIGUSR1 handler");
+        return 1;
+    }
+    // The default loader must release the target without retaining a debugger
+    // stop or changing the disposition of later signals. No x87 arithmetic is
+    // involved, so a failure here isolates process control from translation.
+    for (int i = 1; i <= 100; ++i) {
+        if (raise(SIGUSR1) != 0 || handled != i) {
+            puts("FAIL SIGUSR1 delivery after detach");
+            return 1;
+        }
+    }
+    puts("PASS SIGUSR1 delivery after detach");
+    return 0;
+}


### PR DESCRIPTION
The current macos-26 runner (26.6.2, XNU 12377.161.14) leaves test_fldconst stopped after the classic default-attach release. PT_DETACH succeeds and clears the traced flag, but the target stops again after the held SIGSTOP exception is replied to. The sidecar waits indefinitely for that stopped target to exit. An unchanged master rerun reproduces the same stall; the previous green run used macOS 26.5.2.

Use the existing reply-before-detach sequence for the measured Tahoe kernel family, starting at XNU 12377.161.14. Keep the current behavior for older Tahoe builds and early Golden Gate kernels. This reuses the method's existing best-effort PT_DETACH behavior, including the traced flag remaining set at resume. A new deterministic SIGUSR1-handler test verifies signal delivery after release independently of x87 arithmetic. The cutoff is the verified build, not a claim about the earliest affected Tahoe release.

Retain a CI watchdog that captures the process group, pipe descriptors and stack samples before terminating a stalled test run. Timeouts fail with exit 124 and diagnostics are uploaded on failure. Temporary detach-state logging was removed from the final change.

The [unchanged-runtime capture](https://github.com/athei/x87sidecar/actions/runs/34223742822) and [classic detach trace](https://github.com/athei/x87sidecar/actions/runs/34224407244) establish the blocked processes and release order. The [candidate trace](https://github.com/athei/x87sidecar/actions/runs/34224976897) shows the replacement sequence balancing its suspend and the first test completing in 0.223 seconds on the same runner image.

Validation: [final CI](https://github.com/athei/x87sidecar/actions/runs/34225476607) at 02a173f passed build, runtime probe and all 1000 harness invocations (998 passed, 2 known stock divergences, 0 failed) on macOS 26.6.2. Local Release builds and 22 first-test/signal-test harness invocations passed on macOS 27. The watchdog passed six process-level checks.
