### PR TITLE
Default CoD2 pitch block to stock Rosetta

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,13 +353,24 @@ no steady-state cost:
 
 | variable | effect |
 |---|---|
-| `X87_STOCK_HASH_LIST=0xH,...` | hand the listed blocks to stock Rosetta entirely |
+| `X87_STOCK_HASH_LIST=0xH,...` | hand additional blocks to stock Rosetta entirely |
+| `X87_DISABLE_STOCK_COMPAT=1` | disable built-in stock fallbacks for diagnosis; re-enables the CoD2 crash in [#23](https://github.com/athei/x87sidecar/issues/23) |
 | `X87_STOCK_OPS=f2xm1,...` | hand every block containing one of the opcodes to stock |
 | `X87_LOG_HASH_LIST=0xH,...` | log every translate request of the listed blocks with an uptime stamp |
 | `X87_DIAG_DIR=<dir>` | mirror those logs to `<dir>/x87diag.<pid>.log`, for hosts that lose stdout |
 | `X87_ALWAYS_NONE=1` | the sidecar declines every request; separates a JIT bug from an IPC one |
 | `X87_DISABLE_HOOK=1` | skip the `translate_insn` patch, the benchmark baseline |
 | `X87_NO_DECODE_HOOK=1` | skip the `decode_opcode` patch, so `DC D8` and `ARPL` trap as under stock |
+
+CoD2's ten-instruction Miles pitch block (IR hash `0x129250d0f7976b3f`)
+uses stock Rosetta automatically. The reporter reproduced the live mixer
+crash after both #29 and #32, despite passing the signal tests. Handing
+only this block to stock survived 2.5 hours of play, with no measurable
+FPS loss reported. This is a compatibility fallback, not a resolution of
+the accelerated block's underlying fault. Other blocks remain accelerated.
+`X87_STOCK_HASH_LIST` adds exclusions; an empty or dummy list does not
+remove the built-in fallback. Use `X87_DISABLE_STOCK_COMPAT=1` only when
+investigating the accelerated failure.
 
 Loader and sidecar diagnostics:
 

--- a/rosetta_core/src/ConfigEnv.cpp
+++ b/rosetta_core/src/ConfigEnv.cpp
@@ -211,6 +211,19 @@ RosettaConfig load_config_from_env() {
         std::printf("[rosettax87] X87_STOCK_HASH_LIST: %zu unique hashes\n",
                     cfg.x87_stock_hash_list.size());
     }
+    // CoD2's Miles pitch block still corrupts a multiplier in live play
+    // after #29 and #32. Stock execution of this exact IR stream survived
+    // the reporter's 2.5-hour control; the accelerated root cause is open
+    // in #23. Keep that proven fallback enabled without an environment
+    // workaround. User exclusions are additive, including a dummy list.
+    // The opt-out is for investigating the failing accelerated path.
+    if (!env_truthy("X87_DISABLE_STOCK_COMPAT")) {
+        cfg.x87_stock_hash_list.push_back(UINT64_C(0x129250d0f7976b3f));
+        std::ranges::sort(cfg.x87_stock_hash_list);
+        cfg.x87_stock_hash_list.erase(
+            std::unique(cfg.x87_stock_hash_list.begin(), cfg.x87_stock_hash_list.end()),
+            cfg.x87_stock_hash_list.end());
+    }
     if (const char* v = std::getenv("X87_LOG_HASH_LIST"); v != nullptr && v[0] != '\0') {
         parse_hash_list(v, cfg.x87_log_hash_list);
         std::printf("[rosettax87] X87_LOG_HASH_LIST: %zu unique hashes\n",
@@ -443,6 +456,9 @@ void print_env_help(std::FILE* out) {
         "                                or profile_analyze)\n"
         "  X87_NO_BRIDGE_HASH_LIST=H,... never bridge the listed blocks (wins over\n"
         "                                the include list)\n"
+        "  X87_DISABLE_STOCK_COMPAT=1   disable built-in stock compatibility fallbacks\n"
+        "                                for diagnosis. Re-enables the CoD2 Miles\n"
+        "                                pitch-block crash tracked in issue #23.\n"
         "  X87_STOCK_HASH_LIST=H,...     hand the listed blocks to stock Rosetta\n"
         "                                entirely: every translate request in a block\n"
         "                                whose IR-content hash is listed replies None,\n"
@@ -450,7 +466,8 @@ void print_env_help(std::FILE* out) {
         "                                per-block exclusion that works under wow64,\n"
         "                                where guest-PC filtering cannot see a module.\n"
         "                                Such a block never reaches the translator, so\n"
-        "                                it has no X87_PROFILE entry or counter\n"
+        "                                its X87_PROFILE execution counter stays zero.\n"
+        "                                Adds to the built-in compatibility list.\n"
         "  X87_STOCK_OPS=name,...        hand to stock every block containing any of\n"
         "                                the listed opcodes (mnemonics, e.g. f2xm1);\n"
         "                                coarse one-run localizer, narrow by hash next\n"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -296,6 +296,11 @@ check_output() {
     fi
 }
 
+# Exercise the accelerated implementation even for compatibility-excluded
+# blocks. The separate stock_compat regression below checks default dispatch,
+# so adding a fallback cannot silently turn signal recovery coverage stock-only.
+export X87_DISABLE_STOCK_COMPAT=1
+
 # ── Phase 1: native Rosetta ───────────────────────────────────────────────────
 echo -e "${BOLD}=== Phase 1: native Rosetta ===${NC}"
 
@@ -643,6 +648,15 @@ if [[ $NATIVE_ONLY -eq 0 && ${#SELECTED_TESTS[@]} -eq 0 ]]; then
 fi
 
 echo ""
+# Verify the automatic compatibility fallback and its explicit diagnostic
+# opt-out. The signal-context fixture contains the exact CoD2 IR hash in
+# both 32-bit and 64-bit mode, plus other accelerated x87 blocks.
+if [[ $NATIVE_ONLY -eq 0 && " ${TESTS[*]} " == *" test_x87_signal_context "* ]]; then
+    EXIT=0
+    OUT=$(bash "$SCRIPT_DIR/test_stock_compat.sh" "$BUILD_DIR" 2>&1) || EXIT=$?
+    check_output "stock_compat" "$OUT" "$EXIT"
+fi
+
 echo "================================================================"
 echo -e "Results: ${GREEN}${PASSED} passed${NC}, ${RED}${FAILED} failed${NC}, ${YELLOW}${XFAILED} stock divergences${NC}, ${YELLOW}${ERRORS} skipped${NC} / ${TOTAL} total"
 

--- a/scripts/test_stock_compat.sh
+++ b/scripts/test_stock_compat.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Verify actual dispatch using the signal-context fixture's CoD2 IR stream.
+# Every target-block execution counter must remain zero with the fallback,
+# while other blocks still execute sidecar code. Opting out must reverse it.
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+BUILD=${1:-"$ROOT/build"}
+LOADER="$BUILD/bin/x87sidecar_entitled"
+FIXTURE="$BUILD/bin/tests/test_x87_signal_context"
+ANALYZER="$BUILD/bin/profile_analyze"
+HASH=0x129250d0f7976b3f
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/x87-stock-compat.XXXXXX")
+trap 'rm -rf "$WORK"' EXIT
+
+run_case() {
+    local name=$1 accelerated=$2
+    shift 2
+    local output dump
+    # Do not inherit another run's X87_PROFILE path or diagnostic knobs.
+    # The prefix expansion is supported by macOS's Bash 3.2.
+    output=$(
+        for setting in "${!X87_@}"; do unset "$setting"; done
+        export X87_NO_PREAUTH=1 X87_PROFILE="$WORK/$name.prof"
+        env "$@" "$LOADER" "$FIXTURE" 2>&1
+    ) || { printf '%s\n' "$output"; return 1; }
+    if [[ $(grep -c '^PASS  signal context ' <<<"$output") -ne 20 ]] ||
+       grep -q '^FAIL' <<<"$output"; then
+        printf 'FAIL  stock_compat %s: signal-context fixture failed\n%s\n' "$name" "$output"
+        return 1
+    fi
+    # Profiling paths include the target PID on current main.
+    local profiles=("$WORK/$name.prof"*)
+    if [[ ${#profiles[@]} -ne 1 || ! -f ${profiles[0]} ]]; then
+        printf 'FAIL  stock_compat %s: missing or ambiguous profile\n' "$name"
+        return 1
+    fi
+    dump=$("$ANALYZER" "${profiles[0]}" --dump-block-by-hash "$HASH" 2>&1)
+    if ! awk -v accelerated="$accelerated" '
+        /^# block_id=/ {
+            found++
+            for (i = 1; i <= NF; i++) {
+                if ($i ~ /^exec_count=/) {
+                    split($i, pair, "=")
+                    count += pair[2]
+                }
+            }
+        }
+        END { exit !(found > 0 && (accelerated ? count > 0 : count == 0)) }
+    ' <<<"$dump"; then
+        printf 'FAIL  stock_compat %s: wrong dispatch\n%s\n' "$name" "$dump"
+        return 1
+    fi
+    if ! grep -qE 'wrote [0-9]+ block counters; max=[1-9][0-9]*' <<<"$output"; then
+        printf 'FAIL  stock_compat %s: no other accelerated blocks\n%s\n' "$name" "$output"
+        return 1
+    fi
+    printf 'PASS  stock_compat %s\n' "$name"
+}
+
+run_case default 0
+run_case dummy_list 0 X87_STOCK_HASH_LIST=0x1
+run_case disabled 1 X87_DISABLE_STOCK_COMPAT=1
+run_case explicit_list 0 X87_DISABLE_STOCK_COMPAT=1 X87_STOCK_HASH_LIST="$HASH"


### PR DESCRIPTION
CoD2's Miles mixer still crashes after #29 and #32, even though the signal regressions pass. Enable the reporter's validated stock fallback for IR hash `0x129250d0f7976b3f` by default. Every request in that block takes the existing stock path; other blocks retain sidecar translation. The reporter's manual fallback survived 2.5 hours of play with no measurable FPS loss reported.

User stock hash lists add to the built-in exclusion, so an empty or dummy list cannot accidentally remove it. `X87_DISABLE_STOCK_COMPAT=1` restores the accelerated path for investigation and leaves explicit user exclusions active.

The new dispatch regression runs the exact block in 32-bit and 64-bit signal-context fixtures. It checks profiler counters under default settings, a dummy hash list, diagnostic opt-out, and explicit exclusion: the protected block has zero sidecar executions while other blocks execute sidecar code. The arithmetic suite disables compatibility exclusions so the fallback cannot hide translator regressions.

Validation on macOS 27: 1,021 passed, zero failed, two known stock divergences, zero skipped. A separate pitch-chain matrix passed all 307,968 combinations of input, stack depth, TOP, x87 rounding and MXCSR rounding with the fallback enabled.

This is an automatic compatibility fallback, not a fix to the accelerated block's underlying fault. Related to #23; keep the issue open. The new default still needs the reporter's live-game retest.
