### PR TITLE
Trace native x87 state across translation replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,23 @@ no steady-state cost:
 | `X87_DISABLE_HOOK=1` | skip the `translate_insn` patch, the benchmark baseline |
 | `X87_NO_DECODE_HOOK=1` | skip the `decode_opcode` patch, so `DC D8` and `ARPL` trap as under stock |
 
+For an execution trace of one IR block, set `X87_TRACE_BLOCK=0xH` and
+optionally `X87_TRACE_OUTPUT=/path/prefix` (default `/tmp/x87trace`). The
+sidecar records native x87 state, ARM X0 through X14, NZCV and FPCR at each
+handled reply's entry and exit. A shared ring retains the last 65,536
+records, with per-thread identity and dropped-reservation reporting.
+It allocates 16 MiB only when the selected block is encountered, and writes
+`<prefix>.<target-pid>.x87trace` at exit. Existing files are never overwritten.
+
+`X87_TRACE_STOP_NEGATIVE=1` freezes and writes the ring when ST(0) is negative
+at a reply ending the selected block. This only freezes the diagnostic
+buffer; the guest continues with the same result. For the CoD2 pitch hash
+`0x129250d0f7976b3f`, `python3 tools/x87_trace_analyze.py capture.x87trace`
+checks complete entry/exit pairs against `2^input` and reports the first
+disagreements. Other hashes are decoded without assuming that invariant.
+Tracing changes execution timing; a clean trace is not proof that the live
+bug is fixed. It does not change stock exclusions or repair recorded values.
+
 Loader and sidecar diagnostics:
 
 | variable | effect |

--- a/rosetta_core/CMakeLists.txt
+++ b/rosetta_core/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(rosetta_core STATIC
     src/Translator.cpp
     src/TranslatorCustom.cpp
     src/ProfileRuntime.cpp
+    src/X87Trace.cpp
     src/TranscendentalHelper.cpp
     src/TranslatorX87.cpp
     src/TranslatorX87F80.cpp

--- a/rosetta_core/include/rosetta_core/Config.h
+++ b/rosetta_core/include/rosetta_core/Config.h
@@ -131,6 +131,11 @@ struct RosettaConfig {
     // range filtering cannot target a guest module.
     std::vector<uint64_t> x87_stock_hash_list;  // sorted, binary-searched
 
+    // Opt-in execution trace. Empty path disables both allocation and emission.
+    uint64_t x87_trace_hash;
+    std::string x87_trace_path;
+    bool x87_trace_stop_negative;
+
     // X87_LOG_HASH_LIST — diagnostic: append a timestamped line (uptime
     // seconds, same clock as WINEDEBUG +timestamp) to the X87_DIAG_DIR file
     // for every translate request whose block IR-content hash is listed.

--- a/rosetta_core/include/rosetta_core/X87Trace.h
+++ b/rosetta_core/include/rosetta_core/X87Trace.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+struct IRInstr;
+struct TranslationResult;
+
+namespace x87trace {
+
+constexpr uint64_t kMagic = UINT64_C(0x0031435254373858);  // X87TRC1
+constexpr size_t kCount = 1U << 16;
+
+// Slots have a try-lock, never a spin loop. A stalled writer cannot race a
+// later ring wrap; a reservation that finds a busy slot is simply dropped.
+struct Record {
+    uint64_t locked;
+    uint64_t sequence;  // reservation + 1, published with release ordering
+    uint64_t context;   // Rosetta X18, identifies the executing thread context
+    uint64_t site;      // pc << 32 | instruction index << 1 | exit
+    uint64_t nzcv;
+    uint64_t fpcr;
+    uint64_t native[11];  // CW, SW, tags, eight packed f80 slots, two pad bytes
+    uint64_t gpr[15];     // ARM X0..X14, untouched by trace emission
+};
+static_assert(sizeof(Record) == 256);
+
+struct Control {
+    uint64_t next;
+    uint64_t frozen;
+    uint64_t reserved[30];
+};
+static_assert(sizeof(Control) == 256);
+constexpr size_t kBytes = sizeof(Control) + kCount * sizeof(Record);
+
+struct FileHeader {
+    uint64_t magic = kMagic;
+    uint64_t version = 1;
+    uint64_t hash;
+    uint64_t pid;
+    uint64_t next;
+    uint64_t frozen;
+    uint64_t records = kCount;
+    uint64_t dropped;
+    uint64_t reserved[24]{};
+};
+static_assert(sizeof(FileHeader) == 256);
+
+// Set once, on the sidecar receive thread, before translating the first
+// matching block. The parent VA maps storage also held by the sidecar.
+void set_buffer(uint64_t parent, uint64_t hash, bool stop_negative);
+bool matches(const IRInstr* ir, size_t count);
+void emit_boundary(TranslationResult& tr, uint64_t site, bool end_of_block = false);
+
+}  // namespace x87trace

--- a/rosetta_core/src/ConfigEnv.cpp
+++ b/rosetta_core/src/ConfigEnv.cpp
@@ -323,6 +323,19 @@ RosettaConfig load_config_from_env() {
         cfg.profile_path = p;
     }
 
+    if (const char* v = std::getenv("X87_TRACE_BLOCK"); v != nullptr && v[0] != '\0') {
+        std::vector<uint64_t> hashes;
+        parse_hash_list(v, hashes);
+        if (hashes.size() == 1) {
+            cfg.x87_trace_hash = hashes[0];
+            const char* path = std::getenv("X87_TRACE_OUTPUT");
+            cfg.x87_trace_path = path != nullptr && path[0] != '\0' ? path : "/tmp/x87trace";
+            cfg.x87_trace_stop_negative = env_truthy("X87_TRACE_STOP_NEGATIVE");
+        } else {
+            std::fprintf(stderr, "X87_TRACE_BLOCK requires one IR hash; trace disabled\n");
+        }
+    }
+
     return cfg;
 }
 
@@ -443,6 +456,12 @@ void print_env_help(std::FILE* out) {
         "                                or profile_analyze)\n"
         "  X87_NO_BRIDGE_HASH_LIST=H,... never bridge the listed blocks (wins over\n"
         "                                the include list)\n"
+        "  X87_TRACE_BLOCK=H            record native x87 state at entry/exit of this\n"
+        "                                IR hash; keeps the last 65536 boundary records\n"
+        "  X87_TRACE_OUTPUT=path        output prefix (default /tmp/x87trace); appends\n"
+        "                                .<target-pid>.x87trace, refuses existing files\n"
+        "  X87_TRACE_STOP_NEGATIVE=1    freeze the trace on a negative ST(0) at exit;\n"
+        "                                execution continues unchanged\n"
         "  X87_STOCK_HASH_LIST=H,...     hand the listed blocks to stock Rosetta\n"
         "                                entirely: every translate request in a block\n"
         "                                whose IR-content hash is listed replies None,\n"

--- a/rosetta_core/src/Translator.cpp
+++ b/rosetta_core/src/Translator.cpp
@@ -23,6 +23,7 @@
 #include "rosetta_core/TranslatorX87Helpers.hpp"
 #include "rosetta_core/X87Cache.h"
 #include "rosetta_core/X87IR.h"
+#include "rosetta_core/X87Trace.h"
 
 // True for opcode IDs in the two x87 ranges that Rosetta assigns to x87
 // instructions.  Mirrors the JIT stub's FILTER prologue range check at
@@ -72,6 +73,11 @@ auto Translator::translate_instruction(TranslationResult* translation_result, IR
                                  op != kOpcodeName_finit && op != kOpcodeName_fldenv &&
                                  op != kOpcodeName_fstenv && op != kOpcodeName_fxsave &&
                                  op != kOpcodeName_fxrstor;
+    const bool traced =
+        native_boundary && x87trace::matches(instr_array, static_cast<size_t>(num_instrs));
+    const uint64_t trace_site = uint64_t(instr_array[insn_idx].pc) << 32;
+    if (traced)
+        x87trace::emit_boundary(*translation_result, trace_site | (uint64_t(insn_idx) << 1));
     if (native_boundary)
         TranslatorX87::emit_native_state_boundary(*translation_result, true);
     auto ret =
@@ -107,9 +113,12 @@ auto Translator::translate_instruction(TranslationResult* translation_result, IR
         ret = more;
     }
     if (native_boundary) {
-        if (ret)
+        if (ret) {
             TranslatorX87::emit_native_state_boundary(*translation_result, false);
-        else
+            if (traced)
+                x87trace::emit_boundary(*translation_result, trace_site | (uint64_t(*ret) << 1) | 1,
+                                        *ret == num_instrs);
+        } else
             translation_result->insn_buf.end = start;
     }
     cache.last_next_idx = ret.has_value() ? static_cast<int32_t>(*ret) : -1;

--- a/rosetta_core/src/X87Trace.cpp
+++ b/rosetta_core/src/X87Trace.cpp
@@ -1,0 +1,99 @@
+#include "rosetta_core/X87Trace.h"
+
+#include "rosetta_core/AssemblerHelpers.hpp"
+#include "rosetta_core/ProfileRuntime.h"
+#include "rosetta_core/TranslatorX87Helpers.hpp"
+
+namespace x87trace {
+namespace {
+uint64_t parent_addr;
+uint64_t block_hash;
+bool freeze_negative;
+
+void publish(AssemblerBuffer& buf, int value, int address) {
+    // SWPAL Xvalue, XZR, [Xaddress]. Rosetta's recovery interpreter rejects
+    // STLR even though the hardware accepts it; use its LSE atomic family.
+    buf.emit(0xF8E08000U | (uint32_t(value) << 16) | (uint32_t(address) << 5) | GPR::XZR);
+}
+}  // namespace
+
+void set_buffer(uint64_t parent, uint64_t hash, bool stop_negative) {
+    parent_addr = parent;
+    block_hash = hash;
+    freeze_negative = stop_negative;
+}
+
+bool matches(const IRInstr* ir, size_t count) {
+    return parent_addr != 0 && profile::hash_ir_stream(ir, count) == block_hash;
+}
+
+void emit_boundary(TranslationResult& tr, uint64_t site, bool end_of_block) {
+    const auto saved_mask = tr.free_gpr_mask;
+    tr.free_gpr_mask &= kGprScratchMask;
+    const int header = alloc_free_gpr(tr);
+    const int record = alloc_free_gpr(tr);
+    const int ticket = alloc_free_gpr(tr);
+    const int state = alloc_free_gpr(tr);
+    const int value = alloc_free_gpr(tr);
+    auto& buf = tr.insn_buf;
+
+    // No instruction below writes NZCV or an FP register. All branches
+    // go forward, and busy writers are skipped rather than waited for.
+    emit_movz_movk_abs64(buf, header, parent_addr);
+    emit_ldr_imm(buf, 3, value, header, 1);
+    const auto frozen = buf.end;
+    emit_cbz(buf, 1, 1, value, 0);
+    emit_movn(buf, 1, 2, 0, 1, value);
+    emit_ldaddal_x(buf, value, ticket, header);
+    emit_and_imm(buf, 1, record, 1, 0, 15, ticket);
+    emit_add_sub_shifted_reg(buf, 1, 0, 0, 0, record, 8, header, record);
+    emit_add_imm(buf, 1, 0, 0, 0, sizeof(Control), record, record);
+
+    // LDSETAL Xvalue, Xvalue, [Xrecord]: acquire the one-bit slot lock.
+    buf.emit(0xF8E03000U | (uint32_t(value) << 16) | (uint32_t(record) << 5) | uint32_t(value));
+    const auto busy = buf.end;
+    emit_cbz(buf, 1, 1, value, 0);
+    emit_str_imm(buf, 3, GPR::XZR, record, 1);
+    emit_str_imm(buf, 3, GPR::X18, record, 2);
+    emit_movz_movk_abs64(buf, value, site);
+    emit_str_imm(buf, 3, value, record, 3);
+    emit_mrs_nzcv(buf, value);
+    emit_str_imm(buf, 3, value, record, 4);
+    buf.emit(0xD53B4400U | uint32_t(value));  // MRS Xvalue, FPCR
+    emit_str_imm(buf, 3, value, record, 5);
+    emit_x87_base(buf, tr, state);
+    for (int i = 0; i < 11; ++i) {
+        emit_ldr_imm(buf, 3, value, state, i);
+        emit_str_imm(buf, 3, value, record, 6 + i);
+    }
+    for (int i = 0; i < 15; ++i)
+        emit_str_imm(buf, 3, i, record, 17 + i);
+
+    emit_add_imm(buf, 1, 0, 0, 0, 1, ticket, ticket);
+    emit_add_imm(buf, 1, 0, 0, 0, 8, record, value);
+    publish(buf, ticket, value);
+    publish(buf, GPR::XZR, record);
+
+    if (freeze_negative && end_of_block) {
+        // ST(0)'s physical slot is TOP, at 6 + 10*TOP. Freeze only the
+        // trace buffer, after publishing this record; guest execution
+        // and the bad value are left intact for the original failure.
+        emit_ldr_imm(buf, 1, value, state, 1);
+        emit_bitfield(buf, 0, 2, 0, 11, 13, value, value);
+        emit_add_sub_shifted_reg(buf, 1, 0, 0, 0, value, 1, state, state);
+        emit_add_sub_shifted_reg(buf, 1, 0, 0, 0, value, 3, state, state);
+        emit_ldr_imm(buf, 1, value, state, 7);
+        const auto positive = buf.end;
+        buf.emit(0x36000000U | (15U << 19) | uint32_t(value));
+        emit_add_imm(buf, 1, 0, 0, 0, 8, header, header);
+        emit_movn(buf, 1, 2, 0, 1, value);
+        publish(buf, value, header);
+        buf.data[positive / 4] |= uint32_t((buf.end - positive) / 4) << 5;
+    }
+
+    buf.data[frozen / 4] |= uint32_t((buf.end - frozen) / 4) << 5;
+    buf.data[busy / 4] |= uint32_t((buf.end - busy) / 4) << 5;
+    tr.free_gpr_mask = saved_mask;
+}
+
+}  // namespace x87trace

--- a/rosetta_loader/CMakeLists.txt
+++ b/rosetta_loader/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(x87sidecar
     src/mach_exception.cpp
     src/offset_finder.cpp
     src/sidecar.cpp
+    src/x87_trace.cpp
     src/stub_asm.cpp
     ${MACH_EXC_SERVER}
 )

--- a/rosetta_loader/src/main.cpp
+++ b/rosetta_loader/src/main.cpp
@@ -2265,6 +2265,7 @@ int main(int argc, char* argv[]) try {
     // Window after NOTE_EXIT but before kernel reaps the parent task:
     // mach_vm_read still works against the held task-port send-right.
     // Use it to pull X87_PROFILE counters back into the .prof file.
+    sidecar::flushX87Trace();
     sidecar::dumpCountersIfEnabled(dbg.taskPort());
     // The sampler thread is detached, so returning from main would kill it
     // mid-interval and throw away everything since its last report.

--- a/rosetta_loader/src/sidecar.cpp
+++ b/rosetta_loader/src/sidecar.cpp
@@ -2390,6 +2390,13 @@ TranslateOutcome processTranslateRequest(mach_port_t parentTask, const Translate
     // X87_LOG_HASH_LIST writes an uptime-stamped line per request for the
     // listed blocks (the clock WINEDEBUG=+timestamp prints), so a crash
     // moment in a wine log can be put next to the block's last translation.
+    if (g_rosetta_config != nullptr && !g_rosetta_config->x87_trace_path.empty()) {
+        if (!irc.hash_valid) {
+            irc.hash = profile::hash_ir_stream(localIR, req.num_instrs);
+            irc.hash_valid = true;
+        }
+        maybeEnableX87Trace(parentTask, irc.hash);
+    }
     bool stock_hash_hit = false;
     const bool haveStockHashes =
         g_rosetta_config != nullptr && !g_rosetta_config->x87_stock_hash_list.empty();

--- a/rosetta_loader/src/sidecar.hpp
+++ b/rosetta_loader/src/sidecar.hpp
@@ -14,6 +14,10 @@
 // them. M3 will add real translation work + reply.
 namespace sidecar {
 
+// Allocate tracing only after the selected IR stream is encountered.
+void maybeEnableX87Trace(mach_port_t parentTaskPort, uint64_t hash);
+void flushX87Trace();
+
 // Size of the TranslationResult stock allocates for a translation. Reads and
 // writes of the tracee's TR are bounded by it (writing past it clobbered the
 // adjacent heap chunk holding the block's first emitted ARM word).

--- a/rosetta_loader/src/x87_trace.cpp
+++ b/rosetta_loader/src/x87_trace.cpp
@@ -1,0 +1,159 @@
+#include <fcntl.h>
+#include <mach/mach_vm.h>
+#include <pthread.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "rosetta_core/Config.h"
+#include "rosetta_core/CoreConfig.h"
+#include "rosetta_core/X87Trace.h"
+#include "sidecar.hpp"
+
+namespace sidecar {
+namespace {
+struct TraceState {
+    x87trace::Control* control = nullptr;
+    FILE* file = nullptr;
+    std::string path;
+    uint64_t hash = 0;
+    pid_t pid = 0;
+    std::mutex mutex;
+    std::atomic<bool> stop{false};
+    bool written = false;
+    pthread_t watcher{};
+    bool watcher_started = false;
+};
+TraceState trace;
+
+uint64_t acquire(uint64_t& value) {
+    return std::atomic_ref<uint64_t>(value).load(std::memory_order_acquire);
+}
+
+void writeTrace() {
+    std::scoped_lock guard(trace.mutex);
+    if (trace.control == nullptr || trace.written)
+        return;
+    const uint64_t next = acquire(trace.control->next);
+    const uint64_t floor = next > x87trace::kCount ? next - x87trace::kCount : 0;
+    auto* source = reinterpret_cast<x87trace::Record*>(trace.control + 1);
+    std::vector<x87trace::Record> records(x87trace::kCount);
+    uint64_t valid = 0;
+    for (size_t i = 0; i < x87trace::kCount; ++i) {
+        // Take the producer's same nonblocking lock. This avoids relying
+        // on speculative/torn memcpy reads while an in-flight writer finishes.
+        auto lock = std::atomic_ref<uint64_t>(source[i].locked);
+        if (lock.fetch_or(1, std::memory_order_acquire))
+            continue;
+        const uint64_t sequence = source[i].sequence;
+        if (sequence > floor && sequence <= next &&
+            ((sequence - 1) & (x87trace::kCount - 1)) == i) {
+            records[i] = source[i];
+            records[i].locked = 0;
+            ++valid;
+        }
+        lock.store(0, std::memory_order_release);
+    }
+    x87trace::FileHeader header{
+        .hash = trace.hash,
+        .pid = static_cast<uint64_t>(trace.pid),
+        .next = next,
+        .frozen = acquire(trace.control->frozen),
+        .dropped = std::min<uint64_t>(next, x87trace::kCount) - valid,
+    };
+    const bool ok = std::fwrite(&header, sizeof(header), 1, trace.file) == 1 &&
+                    std::fwrite(records.data(), sizeof(records[0]), records.size(), trace.file) ==
+                        records.size();
+    const bool flushed = std::fflush(trace.file) == 0;
+    const bool closed = std::fclose(trace.file) == 0;
+    trace.file = nullptr;
+    trace.written = true;
+    std::fprintf(stdout, "[x87trace] %s %s: events=%llu retained=%llu dropped=%llu frozen=%llu\n",
+                 ok && flushed && closed ? "wrote" : "write failed for", trace.path.c_str(), next,
+                 valid, header.dropped, header.frozen);
+    std::fflush(stdout);
+}
+
+void* watchTrace(void*) {
+    while (!trace.stop.load(std::memory_order_acquire)) {
+        if (acquire(trace.control->frozen)) {
+            writeTrace();
+            break;
+        }
+        usleep(100000);
+    }
+    return nullptr;
+}
+}  // namespace
+
+void maybeEnableX87Trace(mach_port_t task, uint64_t hash) {
+    if (g_rosetta_config == nullptr || g_rosetta_config->x87_trace_path.empty() ||
+        hash != g_rosetta_config->x87_trace_hash)
+        return;
+    static bool attempted = false;
+    if (attempted)
+        return;
+    attempted = true;
+    std::scoped_lock guard(trace.mutex);
+    if (pid_for_task(task, &trace.pid) != KERN_SUCCESS)
+        return;
+    trace.path = g_rosetta_config->x87_trace_path + "." + std::to_string(trace.pid) + ".x87trace";
+    const int fd = open(trace.path.c_str(), O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC, 0600);
+    if (fd == -1) {
+        std::fprintf(stderr, "[x87trace] cannot create %s: %s\n", trace.path.c_str(),
+                     strerror(errno));
+        return;
+    }
+    trace.file = fdopen(fd, "wb");
+    if (trace.file == nullptr) {
+        close(fd);
+        return;
+    }
+    mach_vm_address_t local = 0, parent = 0;
+    auto kr = mach_vm_allocate(mach_task_self(), &local, x87trace::kBytes, VM_FLAGS_ANYWHERE);
+    if (kr == KERN_SUCCESS) {
+        vm_prot_t current, maximum;
+        kr = mach_vm_remap(task, &parent, x87trace::kBytes, 0, VM_FLAGS_ANYWHERE, mach_task_self(),
+                           local, FALSE, &current, &maximum, VM_INHERIT_NONE);
+    }
+    if (kr != KERN_SUCCESS) {
+        std::fprintf(stderr, "[x87trace] shared allocation failed: %s\n", mach_error_string(kr));
+        if (local)
+            mach_vm_deallocate(mach_task_self(), local, x87trace::kBytes);
+        std::fclose(trace.file);
+        trace.file = nullptr;
+        return;
+    }
+    trace.control = reinterpret_cast<x87trace::Control*>(local);
+    trace.hash = hash;
+    x87trace::set_buffer(parent, hash, g_rosetta_config->x87_trace_stop_negative);
+    std::fprintf(stdout, "[x87trace] hash=0x%016llx output=%s stop_negative=%d\n", hash,
+                 trace.path.c_str(), int(g_rosetta_config->x87_trace_stop_negative));
+    std::fflush(stdout);
+    if (pthread_create(&trace.watcher, nullptr, watchTrace, nullptr) == 0)
+        trace.watcher_started = true;
+    else
+        std::fprintf(stderr, "[x87trace] watcher unavailable; trace will be written at exit\n");
+}
+
+void flushX87Trace() {
+    trace.stop.store(true, std::memory_order_release);
+    pthread_t watcher{};
+    bool started;
+    {
+        std::scoped_lock guard(trace.mutex);
+        watcher = trace.watcher;
+        started = trace.watcher_started;
+    }
+    if (started)
+        pthread_join(watcher, nullptr);
+    writeTrace();
+}
+}  // namespace sidecar

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -643,6 +643,14 @@ if [[ $NATIVE_ONLY -eq 0 && ${#SELECTED_TESTS[@]} -eq 0 ]]; then
 fi
 
 echo ""
+# Tracing must also survive Rosetta's recovery interpreter, not just execute
+# correctly on ARM hardware. The fixture includes the selected hash in both modes.
+if [[ $NATIVE_ONLY -eq 0 && " ${TESTS[*]} " == *" test_x87_signal_context "* ]]; then
+    EXIT=0
+    OUT=$(bash "$SCRIPT_DIR/test_x87_trace.sh" "$BUILD_DIR" 2>&1) || EXIT=$?
+    check_output "x87_trace" "$OUT" "$EXIT"
+fi
+
 echo "================================================================"
 echo -e "Results: ${GREEN}${PASSED} passed${NC}, ${RED}${FAILED} failed${NC}, ${YELLOW}${XFAILED} stock divergences${NC}, ${YELLOW}${ERRORS} skipped${NC} / ${TOTAL} total"
 

--- a/scripts/test_x87_trace.sh
+++ b/scripts/test_x87_trace.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Check native-state tracing under signal recovery, ring wraps and contention.
+set -euo pipefail
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+BUILD=${1:-"$ROOT/build"}
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/x87-trace-test.XXXXXX")
+trap 'rm -rf "$WORK"' EXIT
+
+for fixture in test_x87_signal_context test_x87_trace_threads test_x87_trace_freeze; do
+    selected_hash=0x129250d0f7976b3f
+    if [[ $fixture == test_x87_trace_freeze ]]; then
+        selected_hash=0x1e7ad60db09bb6e8  # fld1; fchs, result is deliberately negative
+    fi
+    output=$(
+        for setting in "${!X87_@}"; do unset "$setting"; done
+        export X87_NO_PREAUTH=1 X87_TRACE_BLOCK="$selected_hash"
+        export X87_TRACE_OUTPUT="$WORK/$fixture" X87_TRACE_STOP_NEGATIVE=1
+        "$BUILD/bin/x87sidecar_entitled" "$BUILD/bin/tests/$fixture" 2>&1
+    ) || { printf '%s\n' "$output"; exit 1; }
+    if grep -q 'FAIL' <<<"$output" || ! grep -q '^PASS' <<<"$output"; then
+        printf 'FAIL  trace fixture %s\n%s\n' "$fixture" "$output"
+        exit 1
+    fi
+    captures=("$WORK/$fixture".*.x87trace)
+    [[ ${#captures[@]} -eq 1 && -f ${captures[0]} ]]
+    if [[ $fixture == test_x87_trace_freeze ]]; then
+        python3 - "$ROOT" "${captures[0]}" <<'PY'
+import runpy, sys
+from pathlib import Path
+trace = runpy.run_path(sys.argv[1] + '/tools/x87_trace_analyze.py')
+header, records = trace['read_trace'](Path(sys.argv[2]))
+assert header['frozen'] and header['events'] == 2 and header['retained'] == 2, header
+assert records[-1]['phase'] == 'exit' and records[-1]['st0'] == -1, records
+PY
+    else
+        python3 "$ROOT/tools/x87_trace_analyze.py" "${captures[0]}" --check
+    fi
+    if [[ $fixture == test_x87_trace_threads ]]; then
+        python3 - "$ROOT" "${captures[0]}" <<'PY'
+import runpy, sys
+from pathlib import Path
+trace = runpy.run_path(sys.argv[1] + '/tools/x87_trace_analyze.py')
+header, records = trace['read_trace'](Path(sys.argv[2]))
+assert not header['frozen'], header
+assert header['events'] > 65536, header
+assert len({r['context'] for r in records}) == 8, 'ring tail lost a producer'
+PY
+    fi
+    printf 'PASS  x87_trace %s\n' "$fixture"
+done

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -95,3 +95,7 @@ add_x86_sample_lowzero(test_decoder_arpl)
 add_x86_sample(test_x87_signal_storm)
 add_x86_sample_lowzero(test_x87_signal_context)
 add_x86_sample(test_x87_native_state)
+
+# Invoked by the opt-in tracing regression, not the arithmetic phase matrix.
+add_x86_sample(test_x87_trace_threads)
+add_x86_sample(test_x87_trace_freeze)

--- a/tests/test_x87_trace_freeze.c
+++ b/tests/test_x87_trace_freeze.c
@@ -1,0 +1,42 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <unistd.h>
+__attribute__((noinline)) static double negative(void) {
+    double result;
+    __asm__ volatile("jmp 1f; 1: fld1; fchs; jmp 2f; 2: fstpl %0" : "=m"(result)::"st");
+    return result;
+}
+int main(void) {
+    setvbuf(stdout, NULL, _IOLBF, 0);
+    for (int i = 0; i < 1000; i++) {
+        if (negative() != -1.0) {
+            puts("FAIL negative fixture");
+            return 1;
+        }
+    }
+    puts("PASS negative fixture: 1000 executions completed");
+    const char* prefix = getenv("X87_TRACE_OUTPUT");
+    if (prefix && *prefix) {
+        char path[4096];
+        int length = snprintf(path, sizeof(path), "%s.%d.x87trace", prefix, getpid());
+        if (length < 0 || (size_t)length >= sizeof(path))
+            return 2;
+        int complete = 0;
+        for (int i = 0; i < 500; ++i) {
+            struct stat info;
+            if (stat(path, &info) == 0 && info.st_size == 256 * (65536 + 1)) {
+                complete = 1;
+                break;
+            }
+            usleep(10000);
+        }
+        if (!complete) {
+            puts("FAIL trace was not written while guest remained alive");
+            return 1;
+        }
+        puts("PASS trace visible while guest remained alive");
+    }
+    puts("PASS negative fixture: exiting");
+    return 0;
+}

--- a/tests/test_x87_trace_threads.c
+++ b/tests/test_x87_trace_threads.c
@@ -1,0 +1,87 @@
+#include <math.h>
+#include <pthread.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <time.h>
+/* Keep workers within one batch of each other so the retained ring tail
+ * includes every producer, even on runners with uneven scheduling. */
+static atomic_int ready, start, running = 8, errors;
+static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t condition = PTHREAD_COND_INITIALIZER;
+static int waiting, generation;
+static void barrier(void) {
+    pthread_mutex_lock(&mutex);
+    int current = generation;
+    if (++waiting == 8) {
+        waiting = 0;
+        generation++;
+        pthread_cond_broadcast(&condition);
+    } else {
+        while (generation == current)
+            pthread_cond_wait(&condition, &mutex);
+    }
+    pthread_mutex_unlock(&mutex);
+}
+static void handler(int sig) {
+    (void)sig;
+    double temporary;
+    __asm__ volatile("fninit; fldpi; fsin; fstpl %0" : "=m"(temporary)::"st");
+}
+__attribute__((noinline)) static double pitch(double x) {
+    double out;
+    __asm__ volatile(
+        ".intel_syntax noprefix; fld QWORD PTR [rax]; jmp 1f; 1: "
+        "fld st(0); frndint; fsubr st(1),st; fxch; fchs; f2xm1; fld1; faddp; fscale; fstp st(1); "
+        "jmp 2f; 2: "
+        "fstp QWORD PTR [rdx]; .att_syntax prefix" ::"a"(&x),
+        "d"(&out)
+        : "memory", "st", "st(1)", "st(2)");
+    return out;
+}
+static void* worker(void* arg) {
+    int id = (int)(intptr_t)arg;
+    atomic_fetch_add(&ready, 1);
+    while (!atomic_load(&start))
+        sched_yield();
+    int failures = 0;
+    for (int n = 0; n < 131072; n++) {
+        double x = -0.005 * (id + 1) - (n & 31) * 0.00001;
+        double got = pitch(x), expected = exp2(x);
+        if (!isfinite(got) || fabs(got - expected) > 1e-12)
+            failures++;
+        if ((n & 1023) == 1023)
+            barrier();
+    }
+    atomic_fetch_add(&errors, failures);
+    atomic_fetch_sub(&running, 1);
+    return 0;
+}
+int main(void) {
+    struct sigaction action = {0};
+    action.sa_handler = handler;
+    sigemptyset(&action.sa_mask);
+    sigaction(SIGUSR1, &action, 0);
+    pthread_t threads[8];
+    for (int i = 0; i < 8; i++)
+        if (pthread_create(&threads[i], 0, worker, (void*)(intptr_t)i))
+            return 2;
+    while (atomic_load(&ready) != 8)
+        sched_yield();
+    atomic_store(&start, 1);
+    int signals = 0;
+    while (atomic_load(&running)) {
+        for (int i = 0; i < 8; i++)
+            if (pthread_kill(threads[i], SIGUSR1) == 0)
+                signals++;
+        struct timespec pause = {0, 20000};
+        nanosleep(&pause, 0);
+    }
+    for (int i = 0; i < 8; i++)
+        pthread_join(threads[i], 0);
+    printf("%s threaded pitch: 1048576 executions errors=%d signals=%d\n",
+           atomic_load(&errors) ? "FAIL" : "PASS", atomic_load(&errors), signals);
+    return atomic_load(&errors) != 0;
+}

--- a/tools/x87_trace_analyze.py
+++ b/tools/x87_trace_analyze.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Read an x87 boundary trace, retaining reservation gaps and thread identity."""
+
+import argparse
+import json
+import math
+import struct
+from pathlib import Path
+
+MAGIC = 0x0031435254373858
+PITCH_HASH = 0x129250D0F7976B3F
+RECORD_BYTES = 256
+
+
+def f80(mantissa, sign_exp):
+    exponent = sign_exp & 0x7fff
+    sign = -1 if sign_exp & 0x8000 else 1
+    if exponent == 0x7fff:
+        return sign * math.inf if mantissa == 0x8000000000000000 else math.nan
+    try:
+        return sign * math.ldexp(float(mantissa), (exponent or 1) - 16383 - 63)
+    except OverflowError:
+        return sign * math.inf
+
+
+def decode_record(data):
+    words = struct.unpack('<32Q', data)
+    locked, sequence, context, site, nzcv, fpcr = words[:6]
+    cw, sw, tags = struct.unpack_from('<3H', data, 48)
+    top = (sw >> 11) & 7
+    slots = []
+    raw_slots = []
+    for physical in range(8):
+        mantissa, sign_exp = struct.unpack_from('<QH', data, 54 + 10 * physical)
+        raw_slots.append(f'{sign_exp:04x}:{mantissa:016x}')
+        tag = (tags >> (2 * physical)) & 3
+        slots.append(None if tag == 3 else f80(mantissa, sign_exp))
+    return dict(sequence=sequence, context=f'0x{context:x}', pc=f'0x{site >> 32:x}',
+                index=(site & 0xffffffff) >> 1, phase='exit' if site & 1 else 'entry',
+                nzcv=f'0x{nzcv:x}', fpcr=f'0x{fpcr:x}', cw=f'0x{cw:04x}',
+                sw=f'0x{sw:04x}', tags=f'0x{tags:04x}', top=top, st0=slots[top],
+                physical=slots, raw=raw_slots, arm_gpr=[f'0x{x:x}' for x in words[17:]],
+                locked=locked)
+
+
+def read_trace(path):
+    data = path.read_bytes()
+    if len(data) < RECORD_BYTES:
+        raise ValueError('missing header (capture did not finish)')
+    magic, version, block_hash, pid, next_id, frozen, count, dropped = struct.unpack_from('<8Q', data)
+    if magic != MAGIC or version != 1 or count != 65536:
+        raise ValueError('unsupported trace header')
+    if len(data) != RECORD_BYTES * (count + 1):
+        raise ValueError('truncated or trailing capture data')
+    records = []
+    floor = max(0, next_id - count)
+    for slot in range(count):
+        offset = RECORD_BYTES * (slot + 1)
+        raw = data[offset:offset + RECORD_BYTES]
+        locked, sequence = struct.unpack_from('<2Q', raw)
+        if sequence == 0:
+            continue
+        if locked or not floor < sequence <= next_id or (sequence - 1) % count != slot:
+            raise ValueError(f'invalid publication at ring slot {slot}')
+        records.append(decode_record(raw))
+    records.sort(key=lambda rec: rec['sequence'])
+    if min(next_id, count) - len(records) != dropped:
+        raise ValueError('record count does not match dropped count')
+    return dict(hash=f'0x{block_hash:016x}', pid=pid, events=next_id, frozen=bool(frozen),
+                retained=len(records), dropped=dropped), records
+
+
+def analyze(header, records):
+    pending = {}
+    pairs = 0
+    replaced_entries = 0
+    unpaired_exits = 0
+    mismatches = []
+    state_changes = []
+    gap_resets = 0
+    previous = None
+    for record in records:
+        if previous is not None and record['sequence'] != previous + 1:
+            # A dropped reservation could belong to any thread. Do not
+            # pair across it and manufacture a numeric disagreement.
+            pending.clear()
+            gap_resets += 1
+        previous = record['sequence']
+        context = record['context']
+        if record['phase'] == 'entry':
+            replaced_entries += context in pending
+            pending[context] = record
+            continue
+        entry = pending.pop(context, None)
+        if entry is None or entry['pc'] != record['pc']:
+            unpaired_exits += 1
+            continue
+        # Only the known ten-instruction exp2 chain has this numeric invariant.
+        # Partial replies and arbitrary selected blocks are still decoded.
+        if int(header['hash'], 16) != PITCH_HASH or entry['index'] != 0 or record['index'] != 10:
+            continue
+        changed = [key for key in ('arm_gpr', 'nzcv', 'fpcr', 'cw', 'top')
+                   if entry[key] != record[key]]
+        if changed:
+            state_changes.append(dict(entry_sequence=entry['sequence'],
+                                      exit_sequence=record['sequence'], fields=changed))
+        x, result = entry['st0'], record['st0']
+        if x is None or not math.isfinite(x) or not -1022 <= x <= 1023:
+            continue
+        pairs += 1
+        expected = 2.0 ** x
+        if result is None or not math.isfinite(result) or not math.isclose(result, expected, rel_tol=1e-12, abs_tol=0):
+            mismatches.append(dict(entry=entry, exit=record, expected=expected))
+    return dict(checked_pairs=pairs, replaced_entries=replaced_entries,
+                unpaired_exits=unpaired_exits, pending_entries=len(pending),
+                mismatches=mismatches, state_changes=state_changes, gap_resets=gap_resets)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('trace', type=Path)
+    parser.add_argument('--json', action='store_true', help='emit the decoded capture and analysis')
+    parser.add_argument('--limit', type=int, default=5, help='maximum mismatch details in text output')
+    parser.add_argument('--check', action='store_true', help='fail if the exp2 pairs are absent or disagree')
+    args = parser.parse_args()
+    header, records = read_trace(args.trace)
+    analysis = analyze(header, records)
+    if args.json:
+        print(json.dumps(dict(header=header, analysis=analysis, records=records), indent=2))
+    else:
+        print(json.dumps(header, sort_keys=True))
+        print(f"checked_pairs={analysis['checked_pairs']} mismatches={len(analysis['mismatches'])} "
+              f"replaced_entries={analysis['replaced_entries']} unpaired_exits={analysis['unpaired_exits']} "
+              f"pending_entries={analysis['pending_entries']} state_changes={len(analysis['state_changes'])} "
+              f"gap_resets={analysis['gap_resets']}")
+        for change in analysis['state_changes'][:args.limit]:
+            print(json.dumps(change))
+        for mismatch in analysis['mismatches'][:args.limit]:
+            print(json.dumps(mismatch, indent=2))
+    return int(args.check and (not analysis['checked_pairs'] or bool(analysis['mismatches']) or bool(analysis['state_changes'])))
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
The live CoD2 mixer crash in #23 survives both previous fixes and passes the existing synthetic tests. Add opt-in tracing so a failing game run can show the actual x87 input and output of the affected IR block.

`X87_TRACE_BLOCK` selects one IR hash. The trace records native x87 state, thread identity, instruction position, ARM X0 through X14, NZCV and FPCR at handled reply boundaries. A shared ring retains 65,536 records and reports dropped reservations. A nonblocking slot lock prevents concurrent writers or ring wraparound from mixing records. Files include the target PID and cannot overwrite an existing capture.

`X87_TRACE_STOP_NEGATIVE=1` freezes and writes the diagnostic buffer when ST(0) is negative at the end of the selected block. Guest execution continues with the same value. The decoder checks complete pairs for the CoD2 pitch hash against `2^input`, reports register changes, and avoids pairing across capture gaps. No arithmetic, fallback policy, or recovery behavior is changed.

Local validation on macOS 27:

- Full suite: 1,021 passed, zero failed, two known stock divergences. Final tracing regressions also pass.
- Signal-context inspection, modification and nested x87 work pass in 32-bit and 64-bit mode. The retained 32,768 complete pairs have no numeric or register disagreements.
- Eight simultaneous producers exercise ring wraparound under signal delivery. The retained window contains all eight contexts without mixed records or dropped reservations.
- A negative-result fixture confirms the buffer freezes after its first pair, is written before process exit, and allows all 1,000 guest calculations to complete.
- A temporary fault-injection build omitted the chain's +1. The trace captured input -0.5 and output -0.2928932188134524, versus expected 0.7071067811865476. The injected arithmetic change is not included.

This is diagnostic work for #23. The live-game root cause remains unproven, and the issue stays open. The reporter's macOS 26.5.1 trigger is the next validation target; a clean run with tracing enabled is not a fix.
