### PR TITLE
fpatan: honour the sign of zero in the x < 0 test (fixes #23)

### DIFF
--- a/rosetta_core/src/TranslatorX87Transcendental.cpp
+++ b/rosetta_core/src/TranslatorX87Transcendental.cpp
@@ -822,8 +822,9 @@ int emit_inline_fyl2x(TranslationResult& a1, AssemblerBuffer& buf, int Xbase, in
 //     for every d = -0.0 — Miles' msssoft.m3d pans a source straight ahead
 //     with acos(dot)/π and got a pan of -0.5, i.e. a NEGATIVE left channel
 //     volume, which the MSSMIXER merge divides into #DE (CoD2 crash, #23).
-//   • den = 0 (both inputs ±0) — z = num/den would be NaN; z is forced to
-//     0 so the quadrant shift alone yields ±0 / ±π as IEEE atan2 does.
+//   • both inputs ±0 — z = num/den would be 0/0 = NaN; z is forced to 0
+//     (only when num AND den are zero, so a NaN input still propagates)
+//     and the quadrant shift alone yields ±0 / ±π as IEEE atan2 does.
 // inf/inf (both infinite) still yields NaN instead of ±π/4 / ±3π/4.
 // FPR-level core of fpatan: returns a freshly-owned pool FPR holding
 // atan2(Dy_in, Dx_in).  Both inputs must be scratch-pool FPRs; the core
@@ -890,19 +891,28 @@ int emit_inline_fpatan_core(TranslationResult& a1, AssemblerBuffer& buf, int Dy_
         free_fpr(a1, Done);
     }
 
-    // 4. z = num / den; den == 0 (both inputs ±0) → z = 0 instead of NaN.
-    //    Dzero is allocated after Dnum's release so the live FPR count
-    //    stays at the step-3 peak.
+    // 4. z = num / den; both inputs ±0 (num == 0 AND den == 0) → z = 0
+    //    instead of the 0/0 NaN.  den == 0 alone is not enough: for
+    //    y = NaN, x = ±0 the unordered step-3 FCMP leaves num = NaN with
+    //    den = |x| = 0, and the quotient must stay NaN.  Both FCMP-zero
+    //    tests are false for NaN, so a NaN in either input keeps z.
+    //    Dnum is reused as the select scratch (its value is consumed by
+    //    the first FCMP) and Dzero takes the slot Dnum would have freed,
+    //    so the live FPR count stays at the step-3 peak.
     const int Dz = alloc_free_fpr(a1);
     emit_fdiv_f64(buf, Dz, Dnum, Dden);
-    free_fpr(a1, Dnum);
     {
         const int Dzero = alloc_free_fpr(a1);
         emit_movi_d_zero(buf, Dzero);
+        // Dnum := (num == 0) ? 0 : z
+        emit_fcmp_zero_f64(buf, Dnum);
+        emit_fcsel_f64(buf, Dnum, Dzero, Dz, /*cond=EQ*/ 0);
+        // z := (den == 0) ? Dnum : z   — i.e. 0 only when both are zero
         emit_fcmp_zero_f64(buf, Dden);
-        emit_fcsel_f64(buf, Dz, Dzero, Dz, /*cond=EQ*/ 0);
+        emit_fcsel_f64(buf, Dz, Dnum, Dz, /*cond=EQ*/ 0);
         free_fpr(a1, Dzero);
     }
+    free_fpr(a1, Dnum);
     free_fpr(a1, Dden);
 
     // 5. shift_a = (x < 0) ? -2.0 : 0.0;  shift = shift_a + shift_b

--- a/rosetta_core/src/TranslatorX87Transcendental.cpp
+++ b/rosetta_core/src/TranslatorX87Transcendental.cpp
@@ -811,9 +811,20 @@ int emit_inline_fyl2x(TranslationResult& a1, AssemblerBuffer& buf, int Xbase, in
 //   ret = z + shift·(π/2) + z³·poly
 //   result = bits_to_double(bits(ret) ^ sign_xy)
 //
-// Special cases (zero/inf/NaN) follow whatever IEEE FP arithmetic does;
-// no scalar fallback as in the AdvSIMD source (real game workloads
-// don't feed degenerate inputs to fpatan).
+// Special cases: the AdvSIMD source routes zero/inf/NaN inputs to a
+// scalar fallback; this port has none, so the two degenerate shapes real
+// code does feed it are folded into the main path instead:
+//   • x = -0.0 — "x < 0" is decided on the SIGN BIT (integer compare of
+//     the raw bits), not on an FCMP against zero, which treats -0.0 as
+//     not-negative and leaves shift_a = 0 while sign_xy still flips the
+//     result: atan2(1, -0.0) came out as -π/2 instead of +π/2.  The CRT
+//     acos() (fld1; fadd; fld1; fsub; fmulp; fsqrt; fxch; fpatan) hits this
+//     for every d = -0.0 — Miles' msssoft.m3d pans a source straight ahead
+//     with acos(dot)/π and got a pan of -0.5, i.e. a NEGATIVE left channel
+//     volume, which the MSSMIXER merge divides into #DE (CoD2 crash, #23).
+//   • den = 0 (both inputs ±0) — z = num/den would be NaN; z is forced to
+//     0 so the quadrant shift alone yields ±0 / ±π as IEEE atan2 does.
+// inf/inf (both infinite) still yields NaN instead of ±π/4 / ±3π/4.
 // FPR-level core of fpatan: returns a freshly-owned pool FPR holding
 // atan2(Dy_in, Dx_in).  Both inputs must be scratch-pool FPRs; the core
 // takes ownership (Dy_in is freed after the step-2 FABS, Dx_in after the
@@ -879,16 +890,35 @@ int emit_inline_fpatan_core(TranslationResult& a1, AssemblerBuffer& buf, int Dy_
         free_fpr(a1, Done);
     }
 
-    // 4. z = num / den
+    // 4. z = num / den; den == 0 (both inputs ±0) → z = 0 instead of NaN.
+    //    Dzero is allocated after Dnum's release so the live FPR count
+    //    stays at the step-3 peak.
     const int Dz = alloc_free_fpr(a1);
     emit_fdiv_f64(buf, Dz, Dnum, Dden);
     free_fpr(a1, Dnum);
+    {
+        const int Dzero = alloc_free_fpr(a1);
+        emit_movi_d_zero(buf, Dzero);
+        emit_fcmp_zero_f64(buf, Dden);
+        emit_fcsel_f64(buf, Dz, Dzero, Dz, /*cond=EQ*/ 0);
+        free_fpr(a1, Dzero);
+    }
     free_fpr(a1, Dden);
 
     // 5. shift_a = (x < 0) ? -2.0 : 0.0;  shift = shift_a + shift_b
-    //    The FCMP-zero is the last read of Dx_in — free it before the
-    //    polynomial's peak-pressure window.
-    emit_fcmp_zero_f64(buf, Dx_in);
+    //    "x < 0" is the sign bit of x, so -0.0 counts as negative (IEEE
+    //    atan2(y, -0.0) = ±π/2, atan2(±0, -0.0) = ±π): FMOV the raw bits
+    //    to a GPR and CMP against zero — N is then the sign bit and the
+    //    MI select below reads it.  This is the last read of Dx_in — free
+    //    it before the polynomial's peak-pressure window.
+    {
+        const int Xbits = alloc_free_gpr(a1);
+        emit_fmov_d_to_x(buf, Xbits, Dx_in);
+        // SUBS XZR, Xbits, #0  (CMP Xbits, #0)
+        emit_add_imm(buf, /*is_64bit=*/1, /*is_sub=*/1, /*is_set_flags=*/1, /*shift=*/0,
+                     /*imm12=*/0, Xbits, GPR::XZR);
+        free_gpr(a1, Xbits);
+    }
     free_fpr(a1, Dx_in);
     const int Dshift = alloc_free_fpr(a1);
     {

--- a/tests/test_fpatan.c
+++ b/tests/test_fpatan.c
@@ -64,6 +64,39 @@ static double do_fpatan(double y, double x) {
     return r;
 }
 
+// Zero results: check_ulp treats +0 and -0 as equal (0 ULP apart); IEEE
+// atan2 distinguishes them, so compare the sign bit too.
+static int check_signed_zero(const char* name, double got, double expected) {
+    if (signbit(got) != signbit(expected)) {
+        printf("FAIL  %-40s  got=%s0 expected=%s0 (sign of zero)\n", name, signbit(got) ? "-" : "+",
+               signbit(expected) ? "-" : "+");
+        failures++;
+        return 0;
+    }
+    return check_ulp(name, got, expected);
+}
+
+// The MSVC CRT acos() body (msssoft.m3d, CoD2SP_s.exe, mss32.dll all carry
+// it): atan2(sqrt((1+d)(1-d)), d).
+static double do_crt_acos(double d) {
+    double r;
+    __asm__ volatile(
+        "fldl  %1\n\t"
+        "fld1\n\t"
+        "fadd  %%st(1), %%st\n\t"
+        "fld1\n\t"
+        "fsub  %%st(2), %%st\n\t"
+        "fmulp\n\t"
+        "fsqrt\n\t"
+        "fxch\n\t"
+        "fpatan\n\t"
+        "fstpl %0\n\t"
+        : "=m"(r)
+        : "m"(d)
+        : "st", "st(1)", "st(2)");
+    return r;
+}
+
 int main(void) {
     check_ulp("fpatan(0, 1)", do_fpatan(0.0, 1.0), atan2(0.0, 1.0));
     check_ulp("fpatan(1, 0)", do_fpatan(1.0, 0.0), atan2(1.0, 0.0));
@@ -75,6 +108,31 @@ int main(void) {
     check_ulp("fpatan(0.5, 0.5)", do_fpatan(0.5, 0.5), atan2(0.5, 0.5));
     check_ulp("fpatan(-3, 4)", do_fpatan(-3.0, 4.0), atan2(-3.0, 4.0));
     check_ulp("fpatan(1.5, 2.5)", do_fpatan(1.5, 2.5), atan2(1.5, 2.5));
+
+    // Signed zeros and infinities.  The AdvSIMD algorithm's "x < 0" test
+    // must be the sign bit: an FCMP against zero misses -0.0 and the
+    // sign_xy XOR then flips the quadrant — atan2(1, -0.0) came out as
+    // -pi/2.  The CRT acos() hits this for every d = -0.0 (Miles'
+    // msssoft.m3d pans a source straight ahead with acos(dot)/pi and
+    // produced a negative channel volume, CoD2 issue #23).  Both-zero
+    // inputs must not divide 0/0 into NaN.  Zero results are compared
+    // with their sign.
+    check_ulp("fpatan(1, -0.0)", do_fpatan(1.0, -0.0), atan2(1.0, -0.0));
+    check_ulp("fpatan(-1, -0.0)", do_fpatan(-1.0, -0.0), atan2(-1.0, -0.0));
+    check_ulp("fpatan(0.5, -0.0)", do_fpatan(0.5, -0.0), atan2(0.5, -0.0));
+    check_ulp("fpatan(0.0, -0.0)", do_fpatan(0.0, -0.0), atan2(0.0, -0.0));
+    check_ulp("fpatan(-0.0, -0.0)", do_fpatan(-0.0, -0.0), atan2(-0.0, -0.0));
+    check_ulp("fpatan(-0.0, -1)", do_fpatan(-0.0, -1.0), atan2(-0.0, -1.0));
+    check_signed_zero("fpatan(0.0, 0.0)", do_fpatan(0.0, 0.0), atan2(0.0, 0.0));
+    check_signed_zero("fpatan(-0.0, 0.0)", do_fpatan(-0.0, 0.0), atan2(-0.0, 0.0));
+    check_signed_zero("fpatan(-0.0, 1)", do_fpatan(-0.0, 1.0), atan2(-0.0, 1.0));
+    check_ulp("fpatan(1, -inf)", do_fpatan(1.0, -INFINITY), atan2(1.0, -INFINITY));
+    check_ulp("fpatan(-1, -inf)", do_fpatan(-1.0, -INFINITY), atan2(-1.0, -INFINITY));
+    check_signed_zero("fpatan(1, +inf)", do_fpatan(1.0, INFINITY), atan2(1.0, INFINITY));
+    check_ulp("fpatan(+inf, 1)", do_fpatan(INFINITY, 1.0), atan2(INFINITY, 1.0));
+    check_ulp("fpatan(-inf, -1)", do_fpatan(-INFINITY, -1.0), atan2(-INFINITY, -1.0));
+    check_ulp("acos(-0.0) via CRT sequence", do_crt_acos(-0.0), acos(-0.0));
+    check_ulp("acos(+0.0) via CRT sequence", do_crt_acos(0.0), acos(0.0));
 
     printf("\n%d failure(s)\n", failures);
     return failures ? 1 : 0;

--- a/tests/test_fpatan.c
+++ b/tests/test_fpatan.c
@@ -76,6 +76,18 @@ static int check_signed_zero(const char* name, double got, double expected) {
     return check_ulp(name, got, expected);
 }
 
+static int check_nan(const char* name, double got) {
+    uint64_t g;
+    memcpy(&g, &got, sizeof(g));
+    if (isnan(got)) {
+        printf("PASS  %-40s  NaN (0x%016llx)\n", name, (unsigned long long)g);
+        return 1;
+    }
+    printf("FAIL  %-40s  got=0x%016llx (%.17g)  expected NaN\n", name, (unsigned long long)g, got);
+    failures++;
+    return 0;
+}
+
 // The MSVC CRT acos() body (msssoft.m3d, CoD2SP_s.exe, mss32.dll all carry
 // it): atan2(sqrt((1+d)(1-d)), d).
 static double do_crt_acos(double d) {
@@ -131,6 +143,17 @@ int main(void) {
     check_signed_zero("fpatan(1, +inf)", do_fpatan(1.0, INFINITY), atan2(1.0, INFINITY));
     check_ulp("fpatan(+inf, 1)", do_fpatan(INFINITY, 1.0), atan2(INFINITY, 1.0));
     check_ulp("fpatan(-inf, -1)", do_fpatan(-INFINITY, -1.0), atan2(-INFINITY, -1.0));
+    // NaN must propagate through the both-zero guard: y = NaN with x = ±0
+    // leaves num = NaN and den = 0, and z must stay NaN, not become 0.
+    check_nan("fpatan(NaN, +0.0)", do_fpatan(NAN, 0.0));
+    check_nan("fpatan(NaN, -0.0)", do_fpatan(NAN, -0.0));
+    check_nan("fpatan(-NaN, +0.0)", do_fpatan(-NAN, 0.0));
+    check_nan("fpatan(-NaN, -0.0)", do_fpatan(-NAN, -0.0));
+    check_nan("fpatan(+0.0, NaN)", do_fpatan(0.0, NAN));
+    check_nan("fpatan(-0.0, NaN)", do_fpatan(-0.0, NAN));
+    check_nan("fpatan(NaN, NaN)", do_fpatan(NAN, NAN));
+    check_nan("fpatan(1, NaN)", do_fpatan(1.0, NAN));
+    check_nan("fpatan(NaN, 1)", do_fpatan(NAN, 1.0));
     check_ulp("acos(-0.0) via CRT sequence", do_crt_acos(-0.0), acos(-0.0));
     check_ulp("acos(+0.0) via CRT sequence", do_crt_acos(0.0), acos(0.0));
 


### PR DESCRIPTION
## Summary

`emit_inline_fpatan_core` decides `x < 0` with an FCMP against zero, which does not see `-0.0`: `shift_a` stays 0 while `sign_xy` (built from the raw sign bits) still flips the result, so `atan2(1, -0.0)` comes out as `-π/2` instead of `+π/2` (and `atan2(-1, -0.0)` as `+π/2`). Both-zero inputs divide `0/0` into NaN instead of `±0 / ±π`.

This is the root cause of #23. The MSVC CRT `acos()` body (`fld1; fadd; fld1; fsub; fmulp; fsqrt; fxch; fpatan` = `atan2(sqrt(1-d²), d)`) hits it for every `d = -0.0`. Miles' `msssoft.m3d` pans a source that sits straight ahead with `acos(dot)/π`; a `-0.0` dot product gives a pan of **-0.5**, i.e. a negative left-channel volume (`left = x·y`, `right = (1-x)·y` → `(-v, 3v)`), and the MSSMIXER merge routine divides that into an integer overflow (`imul 0x10000; div` → #DE). Confirmed with the #35 tracer on the mss32 volume block (`ecx`/`edi` at run exit show `-243/728`, `-208/623`, … with `right/left = -3.000` exactly) and reproduced offline; stock Rosetta passes.

The earlier "forcing the pow block to stock avoids the crash" observation was a coincidence — sorry for the noise on that thread.

## Fix

- `x < 0` is now the sign bit: `FMOV` the raw bits to a GPR, `CMP #0`, the MI select reads N. `-0.0` counts as negative, as IEEE `atan2` requires.
- `den == 0` (both inputs ±0) forces `z = 0`, so the quadrant shift alone yields `±0 / ±π`.
- Peak FPR pressure unchanged (`Dzero` is taken after `Dnum` is released); the core briefly holds one more GPR at step 5, within the transcendental family bound (4). `inf/inf` still yields NaN.

## Test

`tests/test_fpatan.c` gains signed-zero / infinity cases and the CRT `acos()` sequence, with the sign of zero results checked. Before the fix under the sidecar:

```
FAIL  fpatan(1, -0.0)     got=-1.5707963267948966  expected=1.5707963267948966
FAIL  fpatan(-1, -0.0)    got=1.5707963267948966   expected=-1.5707963267948966
FAIL  fpatan(0.0, -0.0)   got=nan                  expected=3.1415926535897931
FAIL  fpatan(-0.0, -0.0)  got=nan                  expected=-3.1415926535897931
FAIL  fpatan(0.0, 0.0)    got=-0 expected=+0 (sign of zero)
FAIL  acos(-0.0) via CRT sequence  got=-1.5707963267948966  expected=1.5707963267948966
8 failure(s)
```

After: `0 failure(s)` natively and under the sidecar (IR path and `X87_DISABLE_X87_IR=1`). Full `scripts/run_tests.sh --no-build`: see below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Suite on this branch (`bash scripts/run_tests.sh --no-build`, `X87_NO_PREAUTH=1`): **987 passed, 0 failed, 2 stock divergences / 989**. In-game: the live trigger (weapon switching in combat) that crashed the mixer within 60–140 s every time went 647 s clean with this build and no block forced to stock; a full 30-minute session follows.
